### PR TITLE
chore: Electron 22 blog post

### DIFF
--- a/blog/electron-22-0.md
+++ b/blog/electron-22-0.md
@@ -38,29 +38,25 @@ If you have any feedback, please share it with us on Twitter, or join our commun
     * [Node 16.17.1 blog post](https://nodejs.org/en/blog/release/v16.17.1/)
 * V8 `10.8`
 
-### New Features
+### Highlighted Features
 
-* Added WebContents `input-event` event. 
-* Added `LoadBrowserProcessSpecificV8Snapshot` as a new fuse that will let the main/browser process load its v8 snapshot from a file at `browser_v8_context_snapshot.bin`. Any other process will use the same path as is used today. [#35266](https://github.com/electron/electron/pull/35266) 
-* Added `WebContents.opener` to access window opener.
-  * Added `webContents.fromFrame(frame)` to get the WebContents corresponding to a WebFrameMain instance. [#35140](https://github.com/electron/electron/pull/35140)
-* Added `app.getSystemLocale()` method. [#35697](https://github.com/electron/electron/pull/35697) 
-* Added `contextBridge.exposeInIsolatedWorld(worldId, key, api)` to expose an API to an `isolatedWorld` within a renderer from a preload script. [#34974](https://github.com/electron/electron/pull/34974) 
-* Added `webContents.close()` method. [#35509](https://github.com/electron/electron/pull/35509) 
-* Added `webFrameMain.origin`. [#35438](https://github.com/electron/electron/pull/35438)
-* Added an `app.getPreferredSystemLanguages()` API to return the user's system languages. [#36291](https://github.com/electron/electron/pull/36291)
-* Added new UtilityProcess API to launch chromium child process with node integration. [#36089](https://github.com/electron/electron/pull/36089) 
-* Added new WebContents event `content-bounds-updated`. [#35533](https://github.com/electron/electron/pull/35533) 
-* Added new `WebContents.ipc` and `WebFrameMain.ipc` APIs. [#34959](https://github.com/electron/electron/pull/34959)
+* Added a new UtilityProcess API to launch a child process with node integration. [#36089](https://github.com/electron/electron/pull/36089)
 * Added support for Web Bluetooth pin pairing on Linux and Windows. [#35416](https://github.com/electron/electron/pull/35416)
+* Added `LoadBrowserProcessSpecificV8Snapshot` as a new fuse that will let the main/browser process load its v8 snapshot from a file at `browser_v8_context_snapshot.bin`. Any other process will use the same path as is used today. [#35266](https://github.com/electron/electron/pull/35266) 
+* Added `WebContents.opener` to access window opener and `webContents.fromFrame(frame)` to get the WebContents corresponding to a WebFrameMain instance. [#35140](https://github.com/electron/electron/pull/35140)
 * Added support for `navigator.mediaDevices.getDisplayMedia` via a new session handler, `ses.setDisplayMediaRequestHandler`. [#30702](https://github.com/electron/electron/pull/30702) 
-* Added support for `serialPort.forget()` as well as a new event `serial-port-revoked` emitted when a given origin is revoked. [#36062](https://github.com/electron/electron/pull/36062)
 
 ## Breaking & API Changes
 
-Below are breaking changes introduced in Electron 22. 
+Below are breaking changes introduced in Electron 22. You can read more about these changes and future changes on the [Planned Breaking Changes](https://github.com/electron/electron/blob/main/docs/breaking-changes.md) page.
 
-### Deprecated: `webContents.incrementCapturerCount(stayHidden, stayAwake)`
+### Breaking Changes
+
+Electron 22 will be the last Electron major version to support Windows 7. Electron follows the planned Chromium deprecation policy, which will [deprecate Windows 7 support in Chromium 109 (read more here)](https://support.google.com/chrome/thread/185534985/sunsetting-support-for-windows-7-8-8-1-in-early-2023?hl=en). Windows 7 will not be supported in Electron 23 and later major releases.
+
+### API Changes
+
+#### Deprecated: `webContents.incrementCapturerCount(stayHidden, stayAwake)`
 
 `webContents.incrementCapturerCount(stayHidden, stayAwake)` has been deprecated.
 It is now automatically handled by `webContents.capturePage` when a page capture completes.
@@ -81,7 +77,7 @@ w.capturePage().then(image => {
 })
 ```
 
-### Deprecated: `webContents.decrementCapturerCount(stayHidden, stayAwake)`
+#### Deprecated: `webContents.decrementCapturerCount(stayHidden, stayAwake)`
 
 `webContents.decrementCapturerCount(stayHidden, stayAwake)` has been deprecated.
 It is now automatically handled by `webContents.capturePage` when a page capture completes.
@@ -102,7 +98,7 @@ w.capturePage().then(image => {
 })
 ```
 
-### Removed: WebContents `new-window` event
+#### Removed: WebContents `new-window` event
 
 The `new-window` event of WebContents has been removed. It is replaced by [`webContents.setWindowOpenHandler()`](api/web-contents.md#contentssetwindowopenhandlerhandler).
 
@@ -118,7 +114,7 @@ webContents.setWindowOpenHandler((details) => {
 })
 ```
 
-### Deprecated: BrowserWindow `scroll-touch-*` events
+#### Deprecated: BrowserWindow `scroll-touch-*` events
 
 The `scroll-touch-begin`, `scroll-touch-end` and `scroll-touch-edge` events on
 BrowserWindow are deprecated. Instead, use the newly available [`input-event`

--- a/blog/electron-22-0.md
+++ b/blog/electron-22-0.md
@@ -14,7 +14,6 @@ slug: electron-22-0
 
 **
 sudowoodo generated release notes
-(doesn't seem to have breaking changes? my scrip )
 https://corp.quip.com/8FIeArIwJ6Lu/v22-release-notes
 **
 
@@ -42,18 +41,18 @@ If you have any feedback, please share it with us on Twitter, or join our commun
 ### New Features
 
 * Added WebContents `input-event` event. 
-* Added `LoadBrowserProcessSpecificV8Snapshot` as a new fuse that will let the main/browser process load its v8 snapshot from a file at `browser_v8_context_snapshot.bin`. Any other process will use the same path as is used today. [#35266](https://github.com/electron/electron/pull/35266) <span style="font-size:small;">(Also in [20](https://github.com/electron/electron/pull/35694), [21](https://github.com/electron/electron/pull/35695))</span>
+* Added `LoadBrowserProcessSpecificV8Snapshot` as a new fuse that will let the main/browser process load its v8 snapshot from a file at `browser_v8_context_snapshot.bin`. Any other process will use the same path as is used today. [#35266](https://github.com/electron/electron/pull/35266) 
 * Added `WebContents.opener` to access window opener.
-  * Added `webContents.fromFrame(frame)` to get the WebContents corresponding to a WebFrameMain instance. [#35140](https://github.com/electron/electron/pull/35140) <span style="font-size:small;">(Also in [21](https://github.com/electron/electron/pull/35819))</span>
-* Added `app.getSystemLocale()` method. [#35697](https://github.com/electron/electron/pull/35697) <span style="font-size:small;">(Also in [21](https://github.com/electron/electron/pull/35794))</span>
+  * Added `webContents.fromFrame(frame)` to get the WebContents corresponding to a WebFrameMain instance. [#35140](https://github.com/electron/electron/pull/35140)
+* Added `app.getSystemLocale()` method. [#35697](https://github.com/electron/electron/pull/35697) 
 * Added `contextBridge.exposeInIsolatedWorld(worldId, key, api)` to expose an API to an `isolatedWorld` within a renderer from a preload script. [#34974](https://github.com/electron/electron/pull/34974) 
 * Added `webContents.close()` method. [#35509](https://github.com/electron/electron/pull/35509) 
-* Added `webFrameMain.origin`. [#35438](https://github.com/electron/electron/pull/35438) <span style="font-size:small;">(Also in [19](https://github.com/electron/electron/pull/35624), [20](https://github.com/electron/electron/pull/35535), [21](https://github.com/electron/electron/pull/35534))</span>
-* Added an `app.getPreferredSystemLanguages()` API to return the user's system languages. [#36291](https://github.com/electron/electron/pull/36291) <span style="font-size:small;">(Also in [21](https://github.com/electron/electron/pull/36290))</span>
+* Added `webFrameMain.origin`. [#35438](https://github.com/electron/electron/pull/35438)
+* Added an `app.getPreferredSystemLanguages()` API to return the user's system languages. [#36291](https://github.com/electron/electron/pull/36291)
 * Added new UtilityProcess API to launch chromium child process with node integration. [#36089](https://github.com/electron/electron/pull/36089) 
 * Added new WebContents event `content-bounds-updated`. [#35533](https://github.com/electron/electron/pull/35533) 
-* Added new `WebContents.ipc` and `WebFrameMain.ipc` APIs. [#34959](https://github.com/electron/electron/pull/34959) <span style="font-size:small;">(Also in [21](https://github.com/electron/electron/pull/35231))</span>
-* Added support for Web Bluetooth pin pairing on Linux and Windows. [#35416](https://github.com/electron/electron/pull/35416) <span style="font-size:small;">(Also in [21](https://github.com/electron/electron/pull/35818))</span>
+* Added new `WebContents.ipc` and `WebFrameMain.ipc` APIs. [#34959](https://github.com/electron/electron/pull/34959)
+* Added support for Web Bluetooth pin pairing on Linux and Windows. [#35416](https://github.com/electron/electron/pull/35416)
 * Added support for `navigator.mediaDevices.getDisplayMedia` via a new session handler, `ses.setDisplayMediaRequestHandler`. [#30702](https://github.com/electron/electron/pull/30702) 
 * Added support for `serialPort.forget()` as well as a new event `serial-port-revoked` emitted when a given origin is revoked. [#36062](https://github.com/electron/electron/pull/36062)
 

--- a/blog/electron-22-0.md
+++ b/blog/electron-22-0.md
@@ -1,0 +1,81 @@
+---
+title: Electron 22.0.0
+date: 2022-11-22T00:00:00.000Z
+authors:
+    - name: vertedinde
+      url: 'https://github.com/vertedinde'
+      image_url: 'https://github.com/vertedinde.png?size=96'
+    - name: georgexu99
+      url: 'https://github.com/georgexu99'
+      image_url: 'https://github.com/georgexu99.png?size=96'
+slug: electron-22-0
+
+---
+
+**
+sudowoodo generated release notes
+(doesn't seem to have breaking changes? my scrip )
+https://corp.quip.com/8FIeArIwJ6Lu/v22-release-notes
+**
+
+Electron 22.0.0 has been released! It includes upgrades to Chromium `108`, V8 `10.8`, and Node.js `16.17.1`. Read below for more details!
+
+---
+
+The Electron team is excited to announce the release of Electron 22.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://releases.electronjs.org/releases/stable). Continue reading for details about this release.
+
+If you have any feedback, please share it with us on Twitter, or join our community [Discord](https://discord.com/invite/electronjs)! Bugs and feature requests can be reported in Electron's [issue tracker](https://github.com/electron/electron/issues).
+
+## Notable Changes
+
+### Stack Changes
+
+* Chromium `108`
+    * [New in Chrome 108](https://developer.chrome.com/blog/new-in-chrome-108/)
+    * [New in Chrome 107](https://developer.chrome.com/blog/new-in-chrome-107/)
+    * [New in DevTools 108](https://developer.chrome.com/blog/new-in-devtools-108/)
+    * [New in DevTools 107](https://developer.chrome.com/blog/new-in-devtools-107/)
+* Node.js `16.17.1`
+    * [Node 16.17.1 blog post](https://nodejs.org/en/blog/release/v16.17.1/)
+* V8 `10.8`
+
+### New Features
+
+* Added WebContents `input-event` event.
+  * Deprecated BrowserWindow `scroll-touch-*` events. [#35531](https://github.com/electron/electron/pull/35531) 
+* Added `LoadBrowserProcessSpecificV8Snapshot` as a new fuse that will let the main/browser process load its v8 snapshot from a file at `browser_v8_context_snapshot.bin`. Any other process will use the same path as is used today. [#35266](https://github.com/electron/electron/pull/35266) <span style="font-size:small;">(Also in [20](https://github.com/electron/electron/pull/35694), [21](https://github.com/electron/electron/pull/35695))</span>
+* Added `WebContents.opener` to access window opener.
+  * Added `webContents.fromFrame(frame)` to get the WebContents corresponding to a WebFrameMain instance. [#35140](https://github.com/electron/electron/pull/35140) <span style="font-size:small;">(Also in [21](https://github.com/electron/electron/pull/35819))</span>
+* Added `app.getSystemLocale()` method. [#35697](https://github.com/electron/electron/pull/35697) <span style="font-size:small;">(Also in [21](https://github.com/electron/electron/pull/35794))</span>
+* Added `contextBridge.exposeInIsolatedWorld(worldId, key, api)` to expose an API to an `isolatedWorld` within a renderer from a preload script. [#34974](https://github.com/electron/electron/pull/34974) 
+* Added `webContents.close()` method. [#35509](https://github.com/electron/electron/pull/35509) 
+* Added `webFrameMain.origin`. [#35438](https://github.com/electron/electron/pull/35438) <span style="font-size:small;">(Also in [19](https://github.com/electron/electron/pull/35624), [20](https://github.com/electron/electron/pull/35535), [21](https://github.com/electron/electron/pull/35534))</span>
+* Added an `app.getPreferredSystemLanguages()` API to return the user's system languages. [#36291](https://github.com/electron/electron/pull/36291) <span style="font-size:small;">(Also in [21](https://github.com/electron/electron/pull/36290))</span>
+* Added new UtilityProcess API to launch chromium child process with node integration. [#36089](https://github.com/electron/electron/pull/36089) 
+* Added new WebContents event `content-bounds-updated`. [#35533](https://github.com/electron/electron/pull/35533) 
+* Added new `WebContents.ipc` and `WebFrameMain.ipc` APIs. [#34959](https://github.com/electron/electron/pull/34959) <span style="font-size:small;">(Also in [21](https://github.com/electron/electron/pull/35231))</span>
+* Added support for Web Bluetooth pin pairing on Linux and Windows. [#35416](https://github.com/electron/electron/pull/35416) <span style="font-size:small;">(Also in [21](https://github.com/electron/electron/pull/35818))</span>
+* Added support for `navigator.mediaDevices.getDisplayMedia` via a new session handler, `ses.setDisplayMediaRequestHandler`. [#30702](https://github.com/electron/electron/pull/30702) 
+* Added support for `serialPort.forget()` as well as a new event `serial-port-revoked` emitted when a given origin is revoked. [#36062](https://github.com/electron/electron/pull/36062)
+
+## Breaking & API Changes
+
+Below are breaking changes introduced in Electron 22. 
+
+## End of Support for 19.x.y
+
+Electron 19.x.y has reached end-of-support as per the project's [support policy](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#version-support-policy). Developers and applications are encouraged to upgrade to a newer version of Electron.
+
+| E19 (May'22) | E20 (Aug'22) | E21 (Sep'22) | E22 (Nov'22) | E23 (Jan'23) |
+| ------------ | ------------ | ------------ | ------------ | ------------ |
+| 19.x.y       | 20.x.y       | 21.x.y       | 22.x.y       | 23.x.y       |
+| 18.x.y       | 19.x.y       | 20.x.y       | 21.x.y       | 22.x.y       |
+| 17.x.y       | 18.x.y       | 19.x.y       | 20.x.y       | 21.x.y       |
+
+## What's Next
+
+In the short term, you can expect the team to continue to focus on keeping up with the development of the major components that make up Electron, including Chromium, Node, and V8.
+
+You can find [Electron's public timeline here](https://www.electronjs.org/docs/latest/tutorial/electron-timelines).
+
+More information about future changes can be found on the [Planned Breaking Changes](https://github.com/electron/electron/blob/main/docs/breaking-changes.md) page.

--- a/blog/electron-22-0.md
+++ b/blog/electron-22-0.md
@@ -12,11 +12,6 @@ slug: electron-22-0
 
 ---
 
-**
-sudowoodo generated release notes
-https://corp.quip.com/8FIeArIwJ6Lu/v22-release-notes
-**
-
 Electron 22.0.0 has been released! It includes upgrades to Chromium `108`, V8 `10.8`, and Node.js `16.17.1`. Read below for more details!
 
 ---

--- a/blog/electron-22-0.md
+++ b/blog/electron-22-0.md
@@ -41,8 +41,7 @@ If you have any feedback, please share it with us on Twitter, or join our commun
 
 ### New Features
 
-* Added WebContents `input-event` event.
-  * Deprecated BrowserWindow `scroll-touch-*` events. [#35531](https://github.com/electron/electron/pull/35531) 
+* Added WebContents `input-event` event. 
 * Added `LoadBrowserProcessSpecificV8Snapshot` as a new fuse that will let the main/browser process load its v8 snapshot from a file at `browser_v8_context_snapshot.bin`. Any other process will use the same path as is used today. [#35266](https://github.com/electron/electron/pull/35266) <span style="font-size:small;">(Also in [20](https://github.com/electron/electron/pull/35694), [21](https://github.com/electron/electron/pull/35695))</span>
 * Added `WebContents.opener` to access window opener.
   * Added `webContents.fromFrame(frame)` to get the WebContents corresponding to a WebFrameMain instance. [#35140](https://github.com/electron/electron/pull/35140) <span style="font-size:small;">(Also in [21](https://github.com/electron/electron/pull/35819))</span>
@@ -61,6 +60,88 @@ If you have any feedback, please share it with us on Twitter, or join our commun
 ## Breaking & API Changes
 
 Below are breaking changes introduced in Electron 22. 
+
+### Deprecated: `webContents.incrementCapturerCount(stayHidden, stayAwake)`
+
+`webContents.incrementCapturerCount(stayHidden, stayAwake)` has been deprecated.
+It is now automatically handled by `webContents.capturePage` when a page capture completes.
+
+```js
+const w = new BrowserWindow({ show: false })
+
+// Removed in Electron 23
+w.webContents.incrementCapturerCount()
+w.capturePage().then(image => {
+  console.log(image.toDataURL())
+  w.webContents.decrementCapturerCount()
+})
+
+// Replace with
+w.capturePage().then(image => {
+  console.log(image.toDataURL())
+})
+```
+
+### Deprecated: `webContents.decrementCapturerCount(stayHidden, stayAwake)`
+
+`webContents.decrementCapturerCount(stayHidden, stayAwake)` has been deprecated.
+It is now automatically handled by `webContents.capturePage` when a page capture completes.
+
+```js
+const w = new BrowserWindow({ show: false })
+
+// Removed in Electron 23
+w.webContents.incrementCapturerCount()
+w.capturePage().then(image => {
+  console.log(image.toDataURL())
+  w.webContents.decrementCapturerCount()
+})
+
+// Replace with
+w.capturePage().then(image => {
+  console.log(image.toDataURL())
+})
+```
+
+### Removed: WebContents `new-window` event
+
+The `new-window` event of WebContents has been removed. It is replaced by [`webContents.setWindowOpenHandler()`](api/web-contents.md#contentssetwindowopenhandlerhandler).
+
+```js
+// Removed in Electron 22
+webContents.on('new-window', (event) => {
+  event.preventDefault()
+})
+
+// Replace with
+webContents.setWindowOpenHandler((details) => {
+  return { action: 'deny' }
+})
+```
+
+### Deprecated: BrowserWindow `scroll-touch-*` events
+
+The `scroll-touch-begin`, `scroll-touch-end` and `scroll-touch-edge` events on
+BrowserWindow are deprecated. Instead, use the newly available [`input-event`
+event](api/web-contents.md#event-input-event) on WebContents.
+
+```js
+// Deprecated
+win.on('scroll-touch-begin', scrollTouchBegin)
+win.on('scroll-touch-edge', scrollTouchEdge)
+win.on('scroll-touch-end', scrollTouchEnd)
+
+// Replace with
+win.webContents.on('input-event', (_, event) => {
+  if (event.type === 'gestureScrollBegin') {
+    scrollTouchBegin()
+  } else if (event.type === 'gestureScrollUpdate') {
+    scrollTouchEdge()
+  } else if (event.type === 'gestureScrollEnd') {
+    scrollTouchEnd()
+  }
+})
+```
 
 ## End of Support for 19.x.y
 

--- a/blog/electron-22-0.md
+++ b/blog/electron-22-0.md
@@ -1,9 +1,9 @@
 ---
 title: Electron 22.0.0
-date: 2022-11-22T00:00:00.000Z
+date: 2022-11-29T00:00:00.000Z
 authors:
-    - name: vertedinde
-      url: 'https://github.com/vertedinde'
+    - name: VerteDinde
+      url: 'https://github.com/VerteDinde'
       image_url: 'https://github.com/vertedinde.png?size=96'
     - name: georgexu99
       url: 'https://github.com/georgexu99'

--- a/blog/electron-22-0.md
+++ b/blog/electron-22-0.md
@@ -114,20 +114,18 @@ Below are breaking changes introduced in Electron 22. You can read more about th
 `webContents.incrementCapturerCount(stayHidden, stayAwake)` has been deprecated.
 It is now automatically handled by `webContents.capturePage` when a page capture completes.
 
-```js
+```diff
 const w = new BrowserWindow({ show: false })
 
-// Removed in Electron 23
-w.webContents.incrementCapturerCount()
-w.capturePage().then(image => {
-  console.log(image.toDataURL())
-  w.webContents.decrementCapturerCount()
-})
+- w.webContents.incrementCapturerCount()
+- w.capturePage().then(image => {
+-   console.log(image.toDataURL())
+-   w.webContents.decrementCapturerCount()
+- })
 
-// Replace with
-w.capturePage().then(image => {
-  console.log(image.toDataURL())
-})
++ w.capturePage().then(image => {
++   console.log(image.toDataURL())
++ })
 ```
 
 #### Deprecated: `webContents.decrementCapturerCount(stayHidden, stayAwake)`
@@ -135,36 +133,32 @@ w.capturePage().then(image => {
 `webContents.decrementCapturerCount(stayHidden, stayAwake)` has been deprecated.
 It is now automatically handled by `webContents.capturePage` when a page capture completes.
 
-```js
+```diff
 const w = new BrowserWindow({ show: false })
 
-// Removed in Electron 23
-w.webContents.incrementCapturerCount()
-w.capturePage().then(image => {
-  console.log(image.toDataURL())
-  w.webContents.decrementCapturerCount()
-})
+- w.webContents.incrementCapturerCount()
+- w.capturePage().then(image => {
+-   console.log(image.toDataURL())
+-   w.webContents.decrementCapturerCount()
+- })
 
-// Replace with
-w.capturePage().then(image => {
-  console.log(image.toDataURL())
-})
++ w.capturePage().then(image => {
++   console.log(image.toDataURL())
++ })
 ```
 
 #### Removed: WebContents `new-window` event
 
 The `new-window` event of WebContents has been removed. It is replaced by [`webContents.setWindowOpenHandler()`](api/web-contents.md#contentssetwindowopenhandlerhandler).
 
-```js
-// Removed in Electron 22
-webContents.on('new-window', (event) => {
-  event.preventDefault()
-})
+```diff
+- webContents.on('new-window', (event) => {
+-   event.preventDefault()
+- })
 
-// Replace with
-webContents.setWindowOpenHandler((details) => {
-  return { action: 'deny' }
-})
++ webContents.setWindowOpenHandler((details) => {
++   return { action: 'deny' }
++ })
 ```
 
 #### Deprecated: BrowserWindow `scroll-touch-*` events
@@ -173,22 +167,22 @@ The `scroll-touch-begin`, `scroll-touch-end` and `scroll-touch-edge` events on
 BrowserWindow are deprecated. Instead, use the newly available [`input-event`
 event](api/web-contents.md#event-input-event) on WebContents.
 
-```js
+```diff
 // Deprecated
-win.on('scroll-touch-begin', scrollTouchBegin)
-win.on('scroll-touch-edge', scrollTouchEdge)
-win.on('scroll-touch-end', scrollTouchEnd)
+- win.on('scroll-touch-begin', scrollTouchBegin)
+- win.on('scroll-touch-edge', scrollTouchEdge)
+- win.on('scroll-touch-end', scrollTouchEnd)
 
 // Replace with
-win.webContents.on('input-event', (_, event) => {
-  if (event.type === 'gestureScrollBegin') {
-    scrollTouchBegin()
-  } else if (event.type === 'gestureScrollUpdate') {
-    scrollTouchEdge()
-  } else if (event.type === 'gestureScrollEnd') {
-    scrollTouchEnd()
-  }
-})
++ win.webContents.on('input-event', (_, event) => {
++   if (event.type === 'gestureScrollBegin') {
++     scrollTouchBegin()
++   } else if (event.type === 'gestureScrollUpdate') {
++     scrollTouchEdge()
++   } else if (event.type === 'gestureScrollEnd') {
++     scrollTouchEnd()
++   }
++ })
 ```
 
 ## End of Support for 19.x.y

--- a/blog/electron-22-0.md
+++ b/blog/electron-22-0.md
@@ -12,7 +12,7 @@ slug: electron-22-0
 
 ---
 
-Electron 22.0.0 has been released! It includes upgrades to Chromium `108`, V8 `10.8`, and Node.js `16.17.1`. Read below for more details!
+Electron 22.0.0 has been released! It includes a new utility process API, updates for Windows 7/8/8.1 support, and upgrades to Chromium `108`, V8 `10.8`, and Node.js `16.17.1`. Read below for more details!
 
 ---
 
@@ -37,21 +37,22 @@ If you have any feedback, please share it with us on Twitter, or join our commun
 
 ### UtilityProcess API [#36089](https://github.com/electron/electron/pull/36089)
 
-The new `UtilityProcess` main process module allows the creation of a lightweight Chromium child process with only Node.js integration while also allowing communication with a sandboxed renderer using `MessageChannel`. The API was designed based on Node.js `child_process.fork` to allow for easier transition, with one primary difference being that the entry point `modulePath` must be from within the packaged application to allow only for trusted scripts to be loaded, unlike the Node.js version which can load from an arbitrary location.
+The new `UtilityProcess` main process module allows the creation of a lightweight Chromium child process with only Node.js integration while also allowing communication with a sandboxed renderer using `MessageChannel`. The API was designed based on Node.js `child_process.fork` to allow for easier transition, with one primary difference being that the entry point `modulePath` must be from within the packaged application to allow only for trusted scripts to be loaded. Additionally the module prevents establishing communication channels with renderers by default, upholding the contract in which the main process is the only trusted process in the application.
 
-Additionally the module prevents establishing communication channels with renderers by default, upholding the contract in which the main process is the only trusted process in the application. Instead the main process is responsible for creating the desired communication channel and sharing the endpoints to the respective child processes.
+You can read more about the [new UtilityProcess API in our docs here](https://www.electronjs.org/docs/latest/api/utility-process).
 
+## Windows 7/8/8.1 Support Update
 
-#### Additional Feature Changes 
+Electron 22 will be the last Electron major version to support Windows 7/8/8.1. Electron follows the planned Chromium deprecation policy, which will [deprecate Windows 7/8/8.1 support in Chromium 109 (read more here)](https://support.google.com/chrome/thread/185534985/sunsetting-support-for-windows-7-8-8-1-in-early-2023?hl=en).
+
+Windows 7/8/8.1 will not be supported in Electron 23 and later major releases.
+
+#### Additional Highlighted Changes 
 
 * Added support for Web Bluetooth pin pairing on Linux and Windows. [#35416](https://github.com/electron/electron/pull/35416)
 * Added `LoadBrowserProcessSpecificV8Snapshot` as a new fuse that will let the main/browser process load its v8 snapshot from a file at `browser_v8_context_snapshot.bin`. Any other process will use the same path as is used today. [#35266](https://github.com/electron/electron/pull/35266) 
 * Added `WebContents.opener` to access window opener and `webContents.fromFrame(frame)` to get the WebContents corresponding to a WebFrameMain instance. [#35140](https://github.com/electron/electron/pull/35140)
 * Added support for `navigator.mediaDevices.getDisplayMedia` via a new session handler, `ses.setDisplayMediaRequestHandler`. [#30702](https://github.com/electron/electron/pull/30702) 
-
-## Windows 7/8/8.1 Support Update
-
-Electron 22 will be the last Electron major version to support Windows 7/8/8.1. Electron follows the planned Chromium deprecation policy, which will [deprecate Windows 7/8/8.1 support in Chromium 109 (read more here)](https://support.google.com/chrome/thread/185534985/sunsetting-support-for-windows-7-8-8-1-in-early-2023?hl=en). Windows 7/8/8.1 will not be supported in Electron 23 and later major releases.
 
 ## Breaking API Changes
 

--- a/blog/electron-22-0.md
+++ b/blog/electron-22-0.md
@@ -47,7 +47,7 @@ Below are breaking changes introduced in Electron 22. You can read more about th
 
 ### Breaking Changes
 
-Electron 22 will be the last Electron major version to support Windows 7. Electron follows the planned Chromium deprecation policy, which will [deprecate Windows 7 support in Chromium 109 (read more here)](https://support.google.com/chrome/thread/185534985/sunsetting-support-for-windows-7-8-8-1-in-early-2023?hl=en). Windows 7 will not be supported in Electron 23 and later major releases.
+Electron 22 will be the last Electron major version to support Windows 7/8/8.1. Electron follows the planned Chromium deprecation policy, which will [deprecate Windows 7/8/8.1 support in Chromium 109 (read more here)](https://support.google.com/chrome/thread/185534985/sunsetting-support-for-windows-7-8-8-1-in-early-2023?hl=en). Windows 7/8/8.1 will not be supported in Electron 23 and later major releases.
 
 ### API Changes
 


### PR DESCRIPTION
Electron 22 blog post
@electron/wg-releases 

Please add a comment for items you think we should highlight in the blog post.

Merge target:  Nov 29th, after 22.0.0 releases successfully

⚠️ Do not merge until the following are completed ⚠️

- [x] update node, v8 and chromium versions from final chrome roll under Stack Changes section (updated as of nov23)
- [x] add a couple new features in tag line sentence
- [x] make sure link for M106 "New In Chrome" blog post is live
- [x] add a few bullets for Highlight Features section
- [x] add any missing items in Breaking Changes section (from breaking changes doc)
- [x] add items for API Changes and/or Deprecated APIs section (from quip doc and breaking changes)
- [x] remove quip link from top of doc