### PR TITLE
build: fix expression for deploying site on docs update

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -28,7 +28,7 @@ jobs:
   build-and-deploy:
     needs: [update-docs]
     # If we are in the "main" branch, it means we have pushed the changed directly and should deploy
-    if: ${{ needs.branch.outputs.branch == 'main' }}
+    if: ${{ needs.update-docs.outputs.branch == 'main' }}
     uses: electron/website/.github/workflows/build-and-deploy.yml@main
     with:
       branch: main


### PR DESCRIPTION
I think there was a typo here so our publishing doesn't actually work when the docs get updated.

See the job output syntax: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-defining-outputs-for-a-job