### PR TITLE
Page update docs/latest/tutorial/tutorial-preload

### DIFF
--- a/docs/latest/tutorial/tutorial-3-preload.md
+++ b/docs/latest/tutorial/tutorial-3-preload.md
@@ -78,8 +78,9 @@ contextBridge.exposeInMainWorld('versions', {
 })
 ```
 
-To attach this script to your renderer process, pass its path to the
-`webPreferences.preload` option in the BrowserWindow constructor:
+To attach this script to your renderer process, you need to add Node.js "path" module, 
+it provides a set of functions for working with paths in the file system `const path = require('path')`, 
+also pass its path to the `webPreferences.preload` option in the BrowserWindow constructor.
 
 ```js {8-10} title="main.js"
 const { app, BrowserWindow } = require('electron')


### PR DESCRIPTION
I noticed that on the website page (https://www.electronjs.org/docs/latest/tutorial/tutorial-preload)  skipped and didn't specify when to add `const path = require('path')`.  Because of this, an error occurs and the program does not start.