### PR TITLE
fix: desktopCapturer is main-process-only module

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -298,7 +298,6 @@ module.exports = {
         'latest/api/clipboard',
         'latest/api/context-bridge',
         'latest/api/crash-reporter',
-        'latest/api/desktop-capturer',
         'latest/api/ipc-renderer',
         'latest/api/native-image',
         'latest/api/web-frame',


### PR DESCRIPTION
Since https://github.com/electron/electron/pull/30720, `desktopCapturer` has only been available in the main process. That changed shipped in v17, so no supported versions have it in the renderer process, this is safe to fix.