### PR TITLE
build: reduce i18n deploy frequency

### DIFF
--- a/.github/workflows/update-i18n-deploy.yml
+++ b/.github/workflows/update-i18n-deploy.yml
@@ -2,7 +2,7 @@ name: 'Update i18n deploy'
 
 on:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '0 0,12 * * *'
 
 jobs:
   deploy:


### PR DESCRIPTION
Reduces it from 48 times a day to twice a day.
It takes about 15 minutes for all our i18n to build so failures get really noisy.