### PR TITLE
docs: update a broken link in the blog page

### DIFF
--- a/blog/forge-v6-release.md
+++ b/blog/forge-v6-release.md
@@ -170,6 +170,6 @@ GitBook instance synced to the
 [import documentation]: https://www.electronforge.io/import-existing-project
 
 [webpack template]: https://www.electronforge.io/templates/webpack-template
-[webpack + typescript template]: https://www.electronforge.io/templates/webpack-typescript-template
+[webpack + typescript template]: https://www.electronforge.io/templates/typescript-+-webpack-template
 [Extending Electron Forge]: https://www.electronforge.io/advanced/extending-electron-forge
 [Why Electron Forge]: https://www.electronforge.io/core-concepts/why-electron-forge


### PR DESCRIPTION
Expected behaviour: open the appropriate page.
Current behaviour (below):
![image](https://user-images.githubusercontent.com/26689027/215312158-578a2777-df5b-4db2-846e-63b754d9fa80.png)
