### PR TITLE
fix(blog): fix npm getting started command

### DIFF
--- a/blog/forge-v6-release.md
+++ b/blog/forge-v6-release.md
@@ -83,7 +83,7 @@ yarn start
   <TabItem value="npm" label="npm">
 
 ```bash
-npm init electron-app@latest my-app --template=webpack
+npm init electron-app@latest my-app -- --template=webpack
 cd my-app
 npm start
 ```


### PR DESCRIPTION
NPM needs an additional `--` according to the official [Getting Started Docs](https://www.electronforge.io/)

When trying out the "Getting started" command from the blog post I noticed that the webpack plugin was not correctly added. Using the command from the official website works as expected.