### PR TITLE
fix: remove old support page from sidebar

### DIFF
--- a/scripts/tasks/create-sidebar.ts
+++ b/scripts/tasks/create-sidebar.ts
@@ -15,6 +15,7 @@ const IGNORE_LIST = [
   // these have limited relevance
   'tutorial/using-pepper-flash-plugin',
   'latest/development/README',
+  'tutorial/support',
 ];
 
 const categoryAliases = new Map([['Tutorial', 'How To']]);

--- a/sidebars.js
+++ b/sidebars.js
@@ -248,13 +248,6 @@ module.exports = {
         },
       ],
     },
-    {
-      type: 'category',
-      label: 'Tutorial',
-      items: [
-        'latest/tutorial/support',
-      ],
-    },
   ],
   api: [
     {


### PR DESCRIPTION
At the moment this is down at the bottom of the sidebar in a duplicated "Tutorial" section, and the page title in the sidebar is awkward, so just remove it all together.

<img width="335" alt="Screen Shot 2023-01-31 at 2 04 12 AM" src="https://user-images.githubusercontent.com/5820654/215729669-0110013d-db12-4487-9863-08ef5a0477e7.png">
