### PR TITLE
ci: update usage of deprecated ::set-output

### DIFF
--- a/.github/workflows/update-docs-branch.yml
+++ b/.github/workflows/update-docs-branch.yml
@@ -28,7 +28,7 @@ jobs:
       - id: branch
         name: Calculate branch
         run: |
-          [[ $(git branch --show-current) =~ ^v[0-9]+-x-y$ ]] && echo "::set-output name=branch::version" || echo "::set-output name=branch::other"
+          [[ $(git branch --show-current) =~ ^v[0-9]+-x-y$ ]] && echo "branch=version" >> $GITHUB_OUTPUT || echo "branch=other" >> $GITHUB_OUTPUT
       - name: Show branch
         run: echo ${{ steps.branch.outputs.branch }}
   # GitHub will not kick the "push-XXX" workflow so we have to publish from here

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: branch
-        run: echo "::set-output name=branch::`git branch --show-current`"
+        run: echo "branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
   # GitHub will not kick the "push-XXX" workflow so we have to publish from here
   build-and-deploy:
     needs: [update-docs]


### PR DESCRIPTION
Changed as per these instructions: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/