### PR TITLE
ci: update GitHub actions workflows

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -31,19 +31,19 @@ jobs:
         if: ${{ inputs.branch == 'main' }}
         run: echo ${{ inputs.branch }}
       # This should be set up from earlier
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
         with:
           node-version: 16
       - name: Install dependencies
-        uses: bahmutov/npm-install@HEAD
+        uses: bahmutov/npm-install@8add8c6d2c8586964896d9fdc639e021312a643f  # tag: v1.8.28
       - name: Test
         run: yarn test
         env:
           CI: true
       # FIXME: this is stalling
       # - name: Download cache
-      #   uses: nick-invision/retry@v2
+      #   uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd  # tag: v2.8.3
       #   with:
       #     timeout_seconds: 300
       #     max_attempts: 3
@@ -60,7 +60,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish "/assets" to Storage if version branch
         if: ${{ inputs.branch == 'version' }}
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd  # tag: v2.8.3
         with:
           timeout_seconds: 300
           max_attempts: 3
@@ -70,7 +70,7 @@ jobs:
           SAS: ${{ secrets.SAS }}
       - name: Publish "/docs" to Storage if version branch
         if: ${{ inputs.branch == 'version' }}
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd  # tag: v2.8.3
         with:
           timeout_seconds: 300
           max_attempts: 3
@@ -80,7 +80,7 @@ jobs:
           SAS: ${{ secrets.SAS }}
       - name: Publish everything to Storage if main branch
         if: ${{ inputs.branch == 'main' }}
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd  # tag: v2.8.3
         with:
           timeout_seconds: 300
           max_attempts: 3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,20 +5,23 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
 
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
         with:
           node-version: 16
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@HEAD
+        uses: bahmutov/npm-install@8add8c6d2c8586964896d9fdc639e021312a643f  # tag: v1.8.28
 
       - name: Test
         run: yarn test

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -11,13 +11,13 @@ jobs:
     name: Upload to Crowdin
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
         with:
           node-version: 16
       - name: Install dependencies
-        uses: bahmutov/npm-install@HEAD
+        uses: bahmutov/npm-install@8add8c6d2c8586964896d9fdc639e021312a643f  # tag: v1.8.28
       - name: Upload sources to Crowdin
         run: 'yarn i18n:upload'
         env:

--- a/.github/workflows/update-docs-branch.yml
+++ b/.github/workflows/update-docs-branch.yml
@@ -10,15 +10,15 @@ jobs:
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
       - name: 'Switch branches'
         # We switch to the version branch or create a new one if needed
         run: git fetch origin && git checkout -t origin/v${{ github.event.client_payload.branch}} || git checkout -b v${{ github.event.client_payload.branch}}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
         with:
           node-version: 16
       - name: Install dependencies
-        uses: bahmutov/npm-install@HEAD
+        uses: bahmutov/npm-install@8add8c6d2c8586964896d9fdc639e021312a643f  # tag: v1.8.28
       - name: 'Prebuild'
         run: 'yarn pre-build ${{ github.event.client_payload.sha }}'
       - name: 'Push changes or create PR'

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -10,12 +10,12 @@ jobs:
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
         with:
           node-version: 16
       - name: Install dependencies
-        uses: bahmutov/npm-install@HEAD
+        uses: bahmutov/npm-install@8add8c6d2c8586964896d9fdc639e021312a643f  # tag: v1.8.28
       - name: 'Prebuild'
         run: 'yarn pre-build ${{ github.event.client_payload.sha }} ${{ github.event.client_payload.branch}}'
       - name: 'Push changes or create PR'

--- a/.github/workflows/update-governance.yml
+++ b/.github/workflows/update-governance.yml
@@ -9,8 +9,8 @@ jobs:
     name: Updates
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
+    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
       with:
         node-version: 16
     - name: Install dependencies

--- a/.github/workflows/update-i18n-deploy.yml
+++ b/.github/workflows/update-i18n-deploy.yml
@@ -4,20 +4,23 @@ on:
   schedule:
     - cron: '0 0,12 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: 'Build and deploy localized site'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
 
       - name: Use Node.js 16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
         with:
           node-version: 16
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@HEAD
+        uses: bahmutov/npm-install@8add8c6d2c8586964896d9fdc639e021312a643f  # tag: v1.8.28
 
       - name: Download crowdin translation
         run: yarn i18n:download


### PR DESCRIPTION
Updates and pins SHAs for actions, also tightens perms in a few spots. Should clear deprecation warnings on workflow runs.