### PR TITLE
fix: add `rel=me` for mastodon link

### DIFF
--- a/docusaurusConfig.ts
+++ b/docusaurusConfig.ts
@@ -158,7 +158,7 @@ const config: Config = {
               href: 'https://twitter.com/electronjs',
             },
             {
-              html: '<a href="https://social.lfx.dev/@electronjs" target="_blank" rel="me" class="footer__link-item">Mastodon<svg width="13.5" height="13.5" aria-hidden="true" viewBox="0 0 24 24" class="iconExternalLink_node_modules-@docusaurus-theme-classic-lib-theme-Icon-ExternalLink-styles-module"><path fill="currentColor" d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"></path></svg></a>',
+              html: '<a href="https://social.lfx.dev/@electronjs" target="_blank" rel="me" class="footer__link-item">Mastodon<svg width="13.5" height="13.5" aria-hidden="true" viewBox="0 0 24 24" style="margin-left: 0.3rem;"><path fill="currentColor" d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"></path></svg></a>',
             },
             {
               label: 'Stack Overflow',

--- a/docusaurusConfig.ts
+++ b/docusaurusConfig.ts
@@ -158,8 +158,7 @@ const config: Config = {
               href: 'https://twitter.com/electronjs',
             },
             {
-              label: 'Mastodon',
-              href: 'https://social.lfx.dev/@electronjs',
+              html: '<a href="https://social.lfx.dev/@electronjs" target="_blank" rel="me" class="footer__link-item">Mastodon<svg width="13.5" height="13.5" aria-hidden="true" viewBox="0 0 24 24" class="iconExternalLink_node_modules-@docusaurus-theme-classic-lib-theme-Icon-ExternalLink-styles-module"><path fill="currentColor" d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"></path></svg></a>',
             },
             {
               label: 'Stack Overflow',


### PR DESCRIPTION
> If you put an HTTPS link in your profile metadata, Mastodon checks if that link resolves to a web page that links back to your Mastodon profile with a special rel=me attribute.

https://docs.joinmastodon.org/user/profile/#verification