### PR TITLE
fix: Navbar carets should never appear on a separate line

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -126,6 +126,8 @@
   &__link {
     font-weight: var(--ifm-font-weight-normal);
     border-bottom: 2px solid transparent;
+    display: block;
+    width: max-content;
 
     &--active {
       color: var(--electron-color-light);


### PR DESCRIPTION
Solved issue #369.
Now navbar carets don't appear on the separate line when transitioning from mobile to desktop.