### PR TITLE
chore: remove `<Layout>` props

### DIFF
--- a/src/pages/community/index.tsx
+++ b/src/pages/community/index.tsx
@@ -4,7 +4,7 @@ import Link from '@docusaurus/Link';
 
 function Community() {
   return (
-    <Layout title="Community">
+    <Layout>
       <div className={'hero hero--electron'}>
         <div className="container">
           <h1 className="hero__title">Community</h1>

--- a/src/pages/fiddle/index.tsx
+++ b/src/pages/fiddle/index.tsx
@@ -134,7 +134,7 @@ export default function FiddlePage() {
   };
 
   return (
-    <Layout title="Electron Fiddle">
+    <Layout>
       <header className={styles.header}>
         <FiddleLogo width={48} height={48} />
         <h1 className={styles.tagline}>

--- a/src/pages/home/_index.tsx
+++ b/src/pages/home/_index.tsx
@@ -19,7 +19,7 @@ import CodeWindow from './_components/CodeWindow';
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
   return (
-    <Layout title={siteConfig.tagline} description={siteConfig.tagline}>
+    <Layout>
       <header className={clsx('hero', 'hero--primary', styles.heroElectron)}>
         <div className="container">
           <div className="row">


### PR DESCRIPTION
These show up as undefined props in our `.tsx` files nowadays.

I think these were removed upstream in https://github.com/facebook/docusaurus/pull/6925