### PR TITLE
build: add twice a day cronjob

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -1,6 +1,9 @@
 name: Push and publish main
 
 on:
+  schedule:
+    # twice a day at midnight and noon
+    - cron: '0 0,12 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
This allows the website to update periodically. It's useful for @electron-bot upstream updates (they don't trigger builds due to a GHA limitation) and to refresh information gathered from Docusaurus plugins on build time (governance, showcase, releases).