### PR TITLE
chore: remove deprecated methods from 24 blog

### DIFF
--- a/blog/electron-24-0.md
+++ b/blog/electron-24-0.md
@@ -52,38 +52,6 @@ nativeImage.createThumbnailFromPath(imagePath, downSize).then((result) => {
 });
 ```
 
-#### Deprecated: `BrowserWindow.setTrafficLightPosition(position)`
-
-`BrowserWindow.setTrafficLightPosition(position)` has been deprecated, the `BrowserWindow.setWindowButtonPosition(position)` API should be used instead which accepts `null` instead of `{ x: 0, y: 0 }` to reset the position to system default.
-
-```js
-// Deprecated in Electron 24
-win.setTrafficLightPosition({ x: 10, y: 10 });
-win.setTrafficLightPosition({ x: 0, y: 0 });
-
-// Replace with
-win.setWindowButtonPosition({ x: 10, y: 10 });
-win.setWindowButtonPosition(null);
-```
-
-#### Deprecated: `BrowserWindow.getTrafficLightPosition()`
-
-`BrowserWindow.getTrafficLightPosition()` has been deprecated, the `BrowserWindow.getWindowButtonPosition()` API should be used instead which returns `null` instead of `{ x: 0, y: 0 }` when there is no custom position.
-
-```js
-// Deprecated in Electron 24
-const pos = win.getTrafficLightPosition();
-if (pos.x === 0 && pos.y === 0) {
-  // No custom position.
-}
-
-// Replace with
-const ret = win.getWindowButtonPosition();
-if (ret === null) {
-  // No custom position.
-}
-```
-
 ### New Features
 
 - Added the ability to filter `HttpOnly` cookies with `cookies.get()`. [#37365](https://github.com/electron/electron/pull/37365)


### PR DESCRIPTION
This PR correct the 24 blog post by removing mention of two methods, which weren't actually deprecated.

Fixes https://github.com/electron/website/issues/401