### PR TITLE
fix(docs): don't convert npm -> pnpm

### DIFF
--- a/docusaurusConfig.ts
+++ b/docusaurusConfig.ts
@@ -212,7 +212,7 @@ const config: Config = {
             apiOptionsClass,
             apiStructurePreviews,
             fiddleEmbedder,
-            [npm2yarn, { sync: true }],
+            [npm2yarn, { sync: true, converters: ['yarn'] }],
           ],
         },
         blog: {


### PR DESCRIPTION
Ref https://github.com/facebook/docusaurus/pull/8690

We don't actively support `pnpm` across many Electron tools (e.g. https://github.com/electron/forge/issues/2633).

Disable this for now on the website.