### PR TITLE
ci: limit concurrency of publish workflow

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
 
+concurrency: publish
+
 jobs:
   # Make a reusable workflow
   crowdin-upload:


### PR DESCRIPTION
Turns out that CrowdIn doesn't like updating the same files in parallel, which causes this workflow to hit errors if you merge two commits one after the other:
* https://github.com/electron/website/actions/runs/5613276938/job/15208951083
* https://github.com/electron/website/actions/runs/5613272569/job/15208938247

You can limit concurrency at just the job level, but seems like the best idea is to limit concurrency of this workflow overall since parallel deploys of the website could run into other issues