### PR TITLE
fix: show badges in API structure previews

### DIFF
--- a/src/components/APIStructurePreview.tsx
+++ b/src/components/APIStructurePreview.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import usePortal from 'react-useportal';
 
+import apiLabels from '../transformers/api-labels';
 import styles from './APIStructurePreview.module.scss';
 
 interface PreviewProps {
@@ -102,7 +103,10 @@ const Card = (props: CardProps) => (
     style={props.position}
   >
     <div className="card__body">
-      <ReactMarkdown allowedElements={['h1', 'ul', 'li', 'code', 'a']}>
+      <ReactMarkdown
+        allowedElements={['h1', 'ul', 'li', 'code', 'a', 'em']}
+        remarkPlugins={[apiLabels]}
+      >
         {props.content}
       </ReactMarkdown>
     </div>

--- a/src/transformers/api-labels.ts
+++ b/src/transformers/api-labels.ts
@@ -33,7 +33,7 @@ const DEPRECATED = 'Deprecated';
 const EXPERIMENTAL = 'Experimental';
 const READONLY = 'Readonly';
 
-async function transformer(tree: Parent) {
+function transformer(tree: Parent) {
   visitParents(tree, 'emphasis', visitor);
 }
 


### PR DESCRIPTION
## Before

<img width="624" alt="Screenshot 2023-07-22 at 2 49 42 PM" src="https://github.com/electron/website/assets/5820654/aa6f6c72-e778-4251-9c81-afffbe4477ec">

## After

<img width="624" alt="Screenshot 2023-07-22 at 2 50 08 PM" src="https://github.com/electron/website/assets/5820654/8868733d-8599-4269-8e8c-a650cb8e9b38">
