### PR TITLE
fix: badge for MAS tags

### DIFF
--- a/src/transformers/api-labels.ts
+++ b/src/transformers/api-labels.ts
@@ -42,6 +42,9 @@ function visitor(node: Emphasis) {
   if (node.children.length === 1 && isText(node.children[0])) {
     const tag = node.children[0].value;
     if (PLATFORMS.includes(tag)) {
+      if (tag === 'mas') {
+        node.children[0].value = tag.toUpperCase();
+      }
       node.data = {
         hProperties: { className: ['badge badge--primary'] },
       } satisfies HastData;

--- a/src/transformers/api-labels.ts
+++ b/src/transformers/api-labels.ts
@@ -11,6 +11,7 @@ import { Emphasis, PhrasingContent, Text } from 'mdast';
  *
  * The raw Markdown nodes to be transformed are:
  * _macOS_
+ * _mas_
  * _Linux_
  * _Windows_
  * _Readonly_
@@ -28,7 +29,7 @@ export default function attacher() {
   return transformer;
 }
 
-const PLATFORMS = ['macOS', 'Windows', 'Linux'];
+const PLATFORMS = ['macOS', 'mas', 'Windows', 'Linux'];
 const DEPRECATED = 'Deprecated';
 const EXPERIMENTAL = 'Experimental';
 const READONLY = 'Readonly';


### PR DESCRIPTION
MAS is one of [the supported platform tags by `@electron/docs-parser`](https://github.com/electron/docs-parser/blob/fddaf1a9e515f7c99d465bd604b3f1a2990e5cbe/src/markdown-helpers.ts#L12-L20) and it's used in the `e/e` docs, so let's badge it like the other platforms.