### PR TITLE
docs: Electron 26 release blog

### DIFF
--- a/blog/electron-26-0.md
+++ b/blog/electron-26-0.md
@@ -35,14 +35,14 @@ The `webContents.getPrinters` method has been deprecated. Use
 `webContents.getPrintersAsync` instead.
 
 ```js
-const w = new BrowserWindow({ show: false })
+const w = new BrowserWindow({ show: false });
 
 // Deprecated
-console.log(w.webContents.getPrinters())
+console.log(w.webContents.getPrinters());
 // Replace with
 w.webContents.getPrintersAsync().then((printers) => {
-  console.log(printers)
-})
+  console.log(printers);
+});
 ```
 
 ### Deprecated: `systemPreferences.{get,set}AppLevelAppearance` and `systemPreferences.appLevelAppearance`
@@ -53,19 +53,19 @@ Use the `nativeTheme` module instead.
 
 ```js
 // Deprecated
-systemPreferences.getAppLevelAppearance()
+systemPreferences.getAppLevelAppearance();
 // Replace with
-nativeTheme.shouldUseDarkColors
+nativeTheme.shouldUseDarkColors;
 
 // Deprecated
-systemPreferences.appLevelAppearance
+systemPreferences.appLevelAppearance;
 // Replace with
-nativeTheme.shouldUseDarkColors
+nativeTheme.shouldUseDarkColors;
 
 // Deprecated
-systemPreferences.setAppLevelAppearance('dark')
+systemPreferences.setAppLevelAppearance('dark');
 // Replace with
-nativeTheme.themeSource = 'dark'
+nativeTheme.themeSource = 'dark';
 ```
 
 ### Deprecated: `alternate-selected-control-text` value for `systemPreferences.getColor`
@@ -75,12 +75,13 @@ has been deprecated. Use `selected-content-background` instead.
 
 ```js
 // Deprecated
-systemPreferences.getColor('alternate-selected-control-text')
+systemPreferences.getColor('alternate-selected-control-text');
 // Replace with
-systemPreferences.getColor('selected-content-background')
+systemPreferences.getColor('selected-content-background');
 ```
 
 ### New Features
+
 - Added `safeStorage.setUsePlainTextEncryption` and `safeStorage.getSelectedStorageBackend` api. [#39107](https://github.com/electron/electron/pull/39107) <span style="font-size:small;">(Also in [25](https://github.com/electron/electron/pull/39325))</span>
 - Added `safeStorage.setUsePlainTextEncryption` and `safeStorage.getSelectedStorageBackend` api. [#39155](https://github.com/electron/electron/pull/39155) <span style="font-size:small;">(Also in [25](https://github.com/electron/electron/pull/39325))</span>
 - Added `senderIsMainFrame` to messages sent via `ipcRenderer.sendTo()`. [#39206](https://github.com/electron/electron/pull/39206) <span style="font-size:small;">(Also in [24](https://github.com/electron/electron/pull/39207), [25](https://github.com/electron/electron/pull/39208))</span>

--- a/blog/electron-26-0.md
+++ b/blog/electron-26-0.md
@@ -1,0 +1,64 @@
+---
+title: Electron 26.0.0
+date: 2023-04-04T00:00:00.000Z
+authors:
+  - name: vertedinde
+    url: 'https://github.com/vertedinde'
+    image_url: 'https://github.com/vertedinde.png?size=96'
+slug: electron-26-0
+---
+
+Electron 26.0.0 has been released! It includes upgrades to Chromium `116.0.5845.62`, V8 `11.2`, and Node.js `18.16.1`. Read below for more details!
+
+---
+
+The Electron team is excited to announce the release of Electron 26.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://releases.electronjs.org/releases/stable). Continue reading for details about this release.
+
+If you have any feedback, please share it with us on Twitter, or join our community [Discord](https://discord.com/invite/electronjs)! Bugs and feature requests can be reported in Electron's [issue tracker](https://github.com/electron/electron/issues).
+
+## Notable Changes
+
+### Stack Changes
+
+- Chromium `116.0.5845.62`
+  - [New in Chrome 116](https://developer.chrome.com/blog/new-in-chrome-116/)
+  - [New in DevTools 116](https://developer.chrome.com/blog/new-in-devtools-116/)
+- Node.js `18.16.1`
+  - [Node 18.16.1 blog post](https://nodejs.org/en/blog/release/v18.16.1/)
+- V8 `11.2`
+
+### Breaking Changes
+
+There are no breaking changes for this release.
+
+### New Features
+
+- Added the ability to filter `HttpOnly` cookies with `cookies.get()`. [#37365](https://github.com/electron/electron/pull/37365)
+- Added `logUsage` to `shell.openExternal()` options, which allows passing the `SEE_MASK_FLAG_LOG_USAGE` flag to `ShellExecuteEx` on Windows. The `SEE_MASK_FLAG_LOG_USAGE` flag indicates a user initiated launch that enables tracking of frequently used programs and other behaviors. [#37291](https://github.com/electron/electron/pull/37291)
+- Added `types` to the `webRequest` filter, adding the ability to filter the requests you listen to.[#37427](https://github.com/electron/electron/pull/37427)
+- Added a new `devtools-open-url` event to `webContents` to allow developers to open new windows with them. [#36774](https://github.com/electron/electron/pull/36774)
+- Added several standard page size options to `webContents.print()`. [#37265](https://github.com/electron/electron/pull/37265)
+- Added the `enableLocalEcho` flag to the session handler `ses.setDisplayMediaRequestHandler()` callback for allowing remote audio input to be echoed in the local output stream when `audio` is a `WebFrameMain`. [#37528](https://github.com/electron/electron/pull/37528)
+- Allow an application-specific username to be passed to `inAppPurchase.purchaseProduct()`. [#35902](https://github.com/electron/electron/pull/35902)
+- Exposed `window.invalidateShadow()` to clear residual visual artifacts on macOS. [#32452](https://github.com/electron/electron/pull/32452)
+- Whole-program optimization is now enabled by default in electron node headers config file, allowing the compiler to perform opimizations with information from all modules in a program as opposed to a per-module (compiland) basis. [#36937](https://github.com/electron/electron/pull/36937)
+- `SystemPreferences::CanPromptTouchID` (macOS) now supports Apple Watch. [#36935](https://github.com/electron/electron/pull/36935)
+
+## End of Support for 23.x.y
+
+Electron 23.x.y has reached end-of-support as per the project's [support policy](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#version-support-policy). Developers and applications are encouraged to upgrade to a newer version of Electron.
+
+| E26 (Aug'23) | E27 (Oct'23) | E28 (Jan'24) |
+| ------------ | ------------ | ------------ |
+| 26.x.y       | 27.x.y       | 28.x.y       |
+| 25.x.y       | 26.x.y       | 27.x.y       |
+| 24.x.y       | 25.x.y       | 26.x.y       |
+| 22.x.y       |              |              |
+
+## What's Next
+
+In the short term, you can expect the team to continue to focus on keeping up with the development of the major components that make up Electron, including Chromium, Node, and V8.
+
+You can find [Electron's public timeline here](https://www.electronjs.org/docs/latest/tutorial/electron-timelines).
+
+More information about future changes can be found on the [Planned Breaking Changes](https://github.com/electron/electron/blob/main/docs/breaking-changes.md) page.

--- a/blog/electron-26-0.md
+++ b/blog/electron-26-0.md
@@ -82,9 +82,9 @@ systemPreferences.getColor('selected-content-background');
 
 ### New Features
 
-- Added `safeStorage.setUsePlainTextEncryption` and `safeStorage.getSelectedStorageBackend` api. [#39107](https://github.com/electron/electron/pull/39107) <span style="font-size:small;">(Also in [25](https://github.com/electron/electron/pull/39325))</span>
-- Added `safeStorage.setUsePlainTextEncryption` and `safeStorage.getSelectedStorageBackend` api. [#39155](https://github.com/electron/electron/pull/39155) <span style="font-size:small;">(Also in [25](https://github.com/electron/electron/pull/39325))</span>
-- Added `senderIsMainFrame` to messages sent via `ipcRenderer.sendTo()`. [#39206](https://github.com/electron/electron/pull/39206) <span style="font-size:small;">(Also in [24](https://github.com/electron/electron/pull/39207), [25](https://github.com/electron/electron/pull/39208))</span>
+- Added `safeStorage.setUsePlainTextEncryption` and `safeStorage.getSelectedStorageBackend` api. [#39107](https://github.com/electron/electron/pull/39107)
+- Added `safeStorage.setUsePlainTextEncryption` and `safeStorage.getSelectedStorageBackend` api. [#39155](https://github.com/electron/electron/pull/39155)
+- Added `senderIsMainFrame` to messages sent via `ipcRenderer.sendTo()`. [#39206](https://github.com/electron/electron/pull/39206)
 - Added support for flagging a Menu as being keyboard initiated. [#38954](https://github.com/electron/electron/pull/38954)
 
 ## End of Support for 23.x.y

--- a/blog/electron-26-0.md
+++ b/blog/electron-26-0.md
@@ -1,6 +1,6 @@
 ---
 title: Electron 26.0.0
-date: 2023-04-04T00:00:00.000Z
+date: 2023-08-15T00:00:00.000Z
 authors:
   - name: vertedinde
     url: 'https://github.com/vertedinde'

--- a/blog/electron-26-0.md
+++ b/blog/electron-26-0.md
@@ -29,20 +29,62 @@ If you have any feedback, please share it with us on Twitter, or join our commun
 
 ### Breaking Changes
 
-There are no breaking changes for this release.
+### Deprecated: `webContents.getPrinters`
+
+The `webContents.getPrinters` method has been deprecated. Use
+`webContents.getPrintersAsync` instead.
+
+```js
+const w = new BrowserWindow({ show: false })
+
+// Deprecated
+console.log(w.webContents.getPrinters())
+// Replace with
+w.webContents.getPrintersAsync().then((printers) => {
+  console.log(printers)
+})
+```
+
+### Deprecated: `systemPreferences.{get,set}AppLevelAppearance` and `systemPreferences.appLevelAppearance`
+
+The `systemPreferences.getAppLevelAppearance` and `systemPreferences.setAppLevelAppearance`
+methods have been deprecated, as well as the `systemPreferences.appLevelAppearance` property.
+Use the `nativeTheme` module instead.
+
+```js
+// Deprecated
+systemPreferences.getAppLevelAppearance()
+// Replace with
+nativeTheme.shouldUseDarkColors
+
+// Deprecated
+systemPreferences.appLevelAppearance
+// Replace with
+nativeTheme.shouldUseDarkColors
+
+// Deprecated
+systemPreferences.setAppLevelAppearance('dark')
+// Replace with
+nativeTheme.themeSource = 'dark'
+```
+
+### Deprecated: `alternate-selected-control-text` value for `systemPreferences.getColor`
+
+The `alternate-selected-control-text` value for `systemPreferences.getColor`
+has been deprecated. Use `selected-content-background` instead.
+
+```js
+// Deprecated
+systemPreferences.getColor('alternate-selected-control-text')
+// Replace with
+systemPreferences.getColor('selected-content-background')
+```
 
 ### New Features
-
-- Added the ability to filter `HttpOnly` cookies with `cookies.get()`. [#37365](https://github.com/electron/electron/pull/37365)
-- Added `logUsage` to `shell.openExternal()` options, which allows passing the `SEE_MASK_FLAG_LOG_USAGE` flag to `ShellExecuteEx` on Windows. The `SEE_MASK_FLAG_LOG_USAGE` flag indicates a user initiated launch that enables tracking of frequently used programs and other behaviors. [#37291](https://github.com/electron/electron/pull/37291)
-- Added `types` to the `webRequest` filter, adding the ability to filter the requests you listen to.[#37427](https://github.com/electron/electron/pull/37427)
-- Added a new `devtools-open-url` event to `webContents` to allow developers to open new windows with them. [#36774](https://github.com/electron/electron/pull/36774)
-- Added several standard page size options to `webContents.print()`. [#37265](https://github.com/electron/electron/pull/37265)
-- Added the `enableLocalEcho` flag to the session handler `ses.setDisplayMediaRequestHandler()` callback for allowing remote audio input to be echoed in the local output stream when `audio` is a `WebFrameMain`. [#37528](https://github.com/electron/electron/pull/37528)
-- Allow an application-specific username to be passed to `inAppPurchase.purchaseProduct()`. [#35902](https://github.com/electron/electron/pull/35902)
-- Exposed `window.invalidateShadow()` to clear residual visual artifacts on macOS. [#32452](https://github.com/electron/electron/pull/32452)
-- Whole-program optimization is now enabled by default in electron node headers config file, allowing the compiler to perform opimizations with information from all modules in a program as opposed to a per-module (compiland) basis. [#36937](https://github.com/electron/electron/pull/36937)
-- `SystemPreferences::CanPromptTouchID` (macOS) now supports Apple Watch. [#36935](https://github.com/electron/electron/pull/36935)
+- Added `safeStorage.setUsePlainTextEncryption` and `safeStorage.getSelectedStorageBackend` api. [#39107](https://github.com/electron/electron/pull/39107) <span style="font-size:small;">(Also in [25](https://github.com/electron/electron/pull/39325))</span>
+- Added `safeStorage.setUsePlainTextEncryption` and `safeStorage.getSelectedStorageBackend` api. [#39155](https://github.com/electron/electron/pull/39155) <span style="font-size:small;">(Also in [25](https://github.com/electron/electron/pull/39325))</span>
+- Added `senderIsMainFrame` to messages sent via `ipcRenderer.sendTo()`. [#39206](https://github.com/electron/electron/pull/39206) <span style="font-size:small;">(Also in [24](https://github.com/electron/electron/pull/39207), [25](https://github.com/electron/electron/pull/39208))</span>
+- Added support for flagging a Menu as being keyboard initiated. [#38954](https://github.com/electron/electron/pull/38954)
 
 ## End of Support for 23.x.y
 


### PR DESCRIPTION
Electron 26 blog post
@electron/wg-releases 

Merge target: after 26.0.0 releases successfully

⚠️ Do not merge until the following are completed ⚠️

- [x] update node, v8 and chromium versions from final chrome roll under Stack Changes section
- [ ] make sure link for "New In Chrome" blog post is live
- [x] update date in slug, E26 date in "end of support for 23.x.y" section 
- [ ] update release notes in github release
