### PR TITLE
fix: increase timeout for API structure preview content

### DIFF
--- a/src/transformers/api-structure-previews.ts
+++ b/src/transformers/api-structure-previews.ts
@@ -161,7 +161,7 @@ function replaceLinkWithPreview(node: Link | LinkReference) {
           `Timed out waiting for API structure content from ${relativeStructurePath}`
         )
       );
-    }, 30000);
+    }, 60000);
 
     const promise = new Promise<string>((resolve_, reject_) => {
       resolve = (value: string) => {


### PR DESCRIPTION
The ["Update i18n deploy" workflow](https://github.com/electron/website/actions/workflows/update-i18n-deploy.yml) is failing intermittently with different errors about timed out waiting for content - the randomness of it makes me think the builds are just a bit slower than expected so this timeout needs to be increased.