### PR TITLE
fix: Update WordPress capitalization on home

### DIFF
--- a/src/pages/home/_index.tsx
+++ b/src/pages/home/_index.tsx
@@ -463,7 +463,7 @@ export default function Home() {
                   href: 'https://code.visualstudio.com/',
                 },
                 {
-                  name: 'Wordpress Desktop',
+                  name: 'WordPress Desktop',
                   image: '/assets/apps/wordpress.svg',
                   href: 'https://apps.wordpress.com/desktop/',
                 },


### PR DESCRIPTION
This PR simply updates the WordPress Desktop capitalization on the home page. It's a nit but I figured why not address it as that capital P is a sticky subject with the WordPress Foundation. 😄 