### PR TITLE
fix: Navbar carets should never appear on a separate line

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -119,8 +119,7 @@
     // use margin instead of padding so that the border-bottom
     // on active looks better
     padding: 0;
-    margin: var(--ifm-navbar-item-padding-vertical)
-      var(--ifm-navbar-item-padding-horizontal);
+    margin: 0.25rem 0.64rem;
   }
 
   &__link {

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -119,7 +119,11 @@
     // use margin instead of padding so that the border-bottom
     // on active looks better
     padding: 0;
-    margin: 0.25rem 0.64rem;
+    margin: var(--ifm-navbar-item-padding-vertical)
+      var(--ifm-navbar-item-padding-horizontal);
+    @media screen and (max-width: 1033px) {
+      margin: 0.25rem 0.64rem;
+    }
   }
 
   &__link {


### PR DESCRIPTION
[fixed the alignment issue.webm](https://github.com/electron/website/assets/134006296/a701541f-b8c0-4f64-9b92-1da76765d80a)

fixed the "Navbar carets should never appear on a separate line #369", now everything's working fine.  
You can also see in the video.

fixed #369