### PR TITLE
fix: correct Fiddle link for x64 AppImage

### DIFF
--- a/src/pages/fiddle/index.tsx
+++ b/src/pages/fiddle/index.tsx
@@ -33,7 +33,7 @@ export default function FiddlePage() {
         arm7l: `https://github.com/electron/fiddle/releases/download/v${version}/electron-fiddle-${version}-1.armv7hl.rpm`,
       },
       appimage: {
-        x64: `https://github.com/electron/fiddle/releases/download/v${version}/Electron.Fiddle-${version}-x86_64.AppImage`,
+        x64: `https://github.com/electron/fiddle/releases/download/v${version}/Electron.Fiddle-${version}-x64.AppImage`,
         arm64: `https://github.com/electron/fiddle/releases/download/v${version}/Electron.Fiddle-${version}-arm64.AppImage`,
         arm7l: `https://github.com/electron/fiddle/releases/download/v${version}/Electron.Fiddle-${version}-armv7hl.AppImage`,
       },


### PR DESCRIPTION
Fixes #467. The artifacts for Fiddle end in `-x64.AppImage`, not `-x86_64.AppImage`.