### PR TITLE
fix: version download link prefix

### DIFF
--- a/src/pages/fiddle/index.tsx
+++ b/src/pages/fiddle/index.tsx
@@ -22,12 +22,12 @@ export default function FiddlePage() {
 
   const downloadLinks = {
     win32: {
-      ia32: `https://github.com/electron/fiddle/releases/download/${version}/electron-fiddle-${version}-win32-ia32-setup.exe`,
-      x64: `https://github.com/electron/fiddle/releases/download/${version}/electron-fiddle-${version}-win32-x64-setup.exe`,
+      ia32: `https://github.com/electron/fiddle/releases/download/v${version}/electron-fiddle-${version}-win32-ia32-setup.exe`,
+      x64: `https://github.com/electron/fiddle/releases/download/v${version}/electron-fiddle-${version}-win32-x64-setup.exe`,
     },
     darwin: {
-      x64: `https://github.com/electron/fiddle/releases/download/${version}/Electron.Fiddle-darwin-x64-${version}.zip`,
-      arm64: `https://github.com/electron/fiddle/releases/download/${version}/Electron.Fiddle-darwin-arm64-${version}.zip`,
+      x64: `https://github.com/electron/fiddle/releases/download/v${version}/Electron.Fiddle-darwin-x64-${version}.zip`,
+      arm64: `https://github.com/electron/fiddle/releases/download/v${version}/Electron.Fiddle-darwin-arm64-${version}.zip`,
     },
     linux: {
       deb: {


### PR DESCRIPTION
Refs https://github.com/electron/website/pull/469
Closes https://github.com/electron/fiddle/issues/1503

Looks like macOS and Windows lost their `v` version prefix in the shuffle.