### PR TITLE
docs: add Electron 28 blog post

### DIFF
--- a/blog/electron-28-0.md
+++ b/blog/electron-28-0.md
@@ -8,7 +8,7 @@ authors:
 slug: electron-28-0
 ---
 
-Electron 28.0.0 has been released! It includes upgrades to Chromium `120.0.6099.5`, V8 `12.0`, and Node.js `18.18.2`.
+Electron 28.0.0 has been released! It includes upgrades to Chromium `120.0.6099.56`, V8 `12.0`, and Node.js `18.18.2`.
 
 ---
 
@@ -20,7 +20,7 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 
 ### Stack Changes
 
-- Chromium `120.0.6099.5`
+- Chromium `120.0.6099.56`
   - New in [Chrome 119](https://developer.chrome.com/blog/new-in-chrome-119/) and in [DevTools 119](https://developer.chrome.com/blog/new-in-devtools-119/)
   - New in [Chrome 120](https://developer.chrome.com/blog/new-in-chrome-120/) and in [DevTools 120](https://developer.chrome.com/blog/new-in-devtools-120/)
 
@@ -29,6 +29,16 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
   - [Node 18.18.1 notes](https://nodejs.org/en/blog/release/v18.18.1/)
   - [Node 18.18.2 notes](https://nodejs.org/en/blog/release/v18.18.2/)
 * V8 `12.0`
+
+### New Features
+
+- Enabled ESM support. [#37535](https://github.com/electron/electron/pull/37535)
+    - For more details, see the [ESM documentation](https://github.com/electron/electron/blob/main/docs/tutorial/esm.md).
+- The `UtilityProcess` API now supports ESM entrypoints. [#40047](https://github.com/electron/electron/pull/40047)
+- Added several properties to the `display` object including `detected`, `maximumCursorSize`, and `nativeOrigin`. [#40554](https://github.com/electron/electron/pull/40554)
+- Added support for `ELECTRON_OZONE_PLATFORM_HINT` environment variable on Linux. [#39792](https://github.com/electron/electron/pull/39792)
+
+In addition to enabling ESM support in Electron itself, Electron Forge also supports using ESM to package, build and develop Electron applications. You can find this support in Forge v7.0.0 or higher: https://github.com/electron/forge/releases/tag/v7.0.0
 
 ### Breaking Changes
 
@@ -92,13 +102,6 @@ console.log(app.runningUnderRosettaTranslation);
 // Replace with
 console.log(app.runningUnderARM64Translation);
 ```
-
-### New Features
-
-- Added ESM support. For more details, see [the ESM limitations document](https://github.com/electron/electron/blob/main/docs/tutorial/esm-limitations.md). [#37535](https://github.com/electron/electron/pull/37535)
-- The `UtilityProcess` API now supports ESM entrypoints. [#40047](https://github.com/electron/electron/pull/40047)
-- Added several properties to the `display` object including `detected`, `maximumCursorSize`, and `nativeOrigin`. [#40554](https://github.com/electron/electron/pull/40554)
-- Added support for `ELECTRON_OZONE_PLATFORM_HINT` environment variable on Linux. [#39792](https://github.com/electron/electron/pull/39792)
 
 ## End of Support for 25.x.y
 

--- a/blog/electron-28-0.md
+++ b/blog/electron-28-0.md
@@ -20,7 +20,7 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 
 ## Highlights
 
-- Implemented support for EcmaScript Modules ESM support. This includes support for ESM in Electron proper, as well as areas such as the `UtilityProcess` API entrypoints. See [#37535](https://github.com/electron/electron/pull/37535). and [#40047](https://github.com/electron/electron/pull/40047) for more details
+- Implemented support for ECMAScript modules or ESM (What are ECMAScript modules? [learn more here](https://nodejs.org/api/esm.html#modules-ecmascript-modules). This includes support for ESM in Electron proper, as well as areas such as the `UtilityProcess` API entrypoints. See [#37535](https://github.com/electron/electron/pull/37535). and [#40047](https://github.com/electron/electron/pull/40047) for more details
 - In addition to enabling ESM support in Electron itself, Electron Forge also supports using ESM to package, build and develop Electron applications. You can find this support in [Forge v7.0.0](https://github.com/electron/forge/releases/tag/v7.0.0) or higher.
 
 ### Stack Changes

--- a/blog/electron-28-0.md
+++ b/blog/electron-28-0.md
@@ -33,7 +33,7 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 ### New Features
 
 - Enabled ESM support. [#37535](https://github.com/electron/electron/pull/37535)
-    - For more details, see the [ESM documentation](https://github.com/electron/electron/blob/main/docs/tutorial/esm.md).
+  - For more details, see the [ESM documentation](https://github.com/electron/electron/blob/main/docs/tutorial/esm.md).
 - The `UtilityProcess` API now supports ESM entrypoints. [#40047](https://github.com/electron/electron/pull/40047)
 - Added several properties to the `display` object including `detected`, `maximumCursorSize`, and `nativeOrigin`. [#40554](https://github.com/electron/electron/pull/40554)
 - Added support for `ELECTRON_OZONE_PLATFORM_HINT` environment variable on Linux. [#39792](https://github.com/electron/electron/pull/39792)

--- a/blog/electron-28-0.md
+++ b/blog/electron-28-0.md
@@ -21,14 +21,15 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 ### Stack Changes
 
 - Chromium `120.0.6099.56`
+
   - New in [Chrome 119](https://developer.chrome.com/blog/new-in-chrome-119/) and in [DevTools 119](https://developer.chrome.com/blog/new-in-devtools-119/)
   - New in [Chrome 120](https://developer.chrome.com/blog/new-in-chrome-120/) and in [DevTools 120](https://developer.chrome.com/blog/new-in-devtools-120/)
 
-* Node `18.18.2`
+- Node `18.18.2`
   - [Node 18.18.0 notes](https://nodejs.org/en/blog/release/v18.18.0/)
   - [Node 18.18.1 notes](https://nodejs.org/en/blog/release/v18.18.1/)
   - [Node 18.18.2 notes](https://nodejs.org/en/blog/release/v18.18.2/)
-* V8 `12.0`
+- V8 `12.0`
 
 ### New Features
 

--- a/blog/electron-28-0.md
+++ b/blog/electron-28-0.md
@@ -20,7 +20,7 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 
 ## Highlights
 
-- Implemented support for ECMAScript modules or ESM (What are ECMAScript modules? [learn more here](https://nodejs.org/api/esm.html#modules-ecmascript-modules). This includes support for ESM in Electron proper, as well as areas such as the `UtilityProcess` API entrypoints. See [#37535](https://github.com/electron/electron/pull/37535). and [#40047](https://github.com/electron/electron/pull/40047) for more details
+- Implemented support for ECMAScript modules or ESM (What are ECMAScript modules? [learn more here](https://nodejs.org/api/esm.html#modules-ecmascript-modules). This includes support for ESM in Electron proper, as well as areas such as the `UtilityProcess` API entrypoints. [See our ESM documentation](https://www.electronjs.org/docs/latest/tutorial/esm) for more details.
 - In addition to enabling ESM support in Electron itself, Electron Forge also supports using ESM to package, build and develop Electron applications. You can find this support in [Forge v7.0.0](https://github.com/electron/forge/releases/tag/v7.0.0) or higher.
 
 ### Stack Changes

--- a/blog/electron-28-0.md
+++ b/blog/electron-28-0.md
@@ -21,12 +21,13 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 ### Stack Changes
 
 - Chromium `120.0.6099.5`
-    - New in [Chrome 119](https://developer.chrome.com/blog/new-in-chrome-119/) and in [DevTools 119](https://developer.chrome.com/blog/new-in-devtools-119/)
-    - New in [Chrome 120](https://developer.chrome.com/blog/new-in-chrome-120/) and in [DevTools 120](https://developer.chrome.com/blog/new-in-devtools-120/)
+  - New in [Chrome 119](https://developer.chrome.com/blog/new-in-chrome-119/) and in [DevTools 119](https://developer.chrome.com/blog/new-in-devtools-119/)
+  - New in [Chrome 120](https://developer.chrome.com/blog/new-in-chrome-120/) and in [DevTools 120](https://developer.chrome.com/blog/new-in-devtools-120/)
+
 * Node `18.18.2`
-    *  [Node 18.18.0 notes](https://nodejs.org/en/blog/release/v18.18.0/)
-    *  [Node 18.18.1 notes](https://nodejs.org/en/blog/release/v18.18.1/)
-    *  [Node 18.18.2 notes](https://nodejs.org/en/blog/release/v18.18.2/)
+  - [Node 18.18.0 notes](https://nodejs.org/en/blog/release/v18.18.0/)
+  - [Node 18.18.1 notes](https://nodejs.org/en/blog/release/v18.18.1/)
+  - [Node 18.18.2 notes](https://nodejs.org/en/blog/release/v18.18.2/)
 * V8 `12.0`
 
 ### Breaking Changes
@@ -45,12 +46,12 @@ system default.
 
 ```js
 // Removed in Electron 28
-win.setTrafficLightPosition({ x: 10, y: 10 })
-win.setTrafficLightPosition({ x: 0, y: 0 })
+win.setTrafficLightPosition({ x: 10, y: 10 });
+win.setTrafficLightPosition({ x: 0, y: 0 });
 
 // Replace with
-win.setWindowButtonPosition({ x: 10, y: 10 })
-win.setWindowButtonPosition(null)
+win.setWindowButtonPosition({ x: 10, y: 10 });
+win.setWindowButtonPosition(null);
 ```
 
 #### Removed: `BrowserWindow.getTrafficLightPosition()`
@@ -62,13 +63,13 @@ position.
 
 ```js
 // Removed in Electron 28
-const pos = win.getTrafficLightPosition()
+const pos = win.getTrafficLightPosition();
 if (pos.x === 0 && pos.y === 0) {
   // No custom position.
 }
 
 // Replace with
-const ret = win.getWindowButtonPosition()
+const ret = win.getWindowButtonPosition();
 if (ret === null) {
   // No custom position.
 }
@@ -87,27 +88,27 @@ Use `app.runningUnderARM64Translation` instead.
 
 ```js
 // Removed
-console.log(app.runningUnderRosettaTranslation)
+console.log(app.runningUnderRosettaTranslation);
 // Replace with
-console.log(app.runningUnderARM64Translation)
+console.log(app.runningUnderARM64Translation);
 ```
 
 ### New Features
 
-- Added ESM support. For more details, see [the ESM limitations document](https://github.com/electron/electron/blob/main/docs/tutorial/esm-limitations.md). [#37535](https://github.com/electron/electron/pull/37535) 
+- Added ESM support. For more details, see [the ESM limitations document](https://github.com/electron/electron/blob/main/docs/tutorial/esm-limitations.md). [#37535](https://github.com/electron/electron/pull/37535)
 - The `UtilityProcess` API now supports ESM entrypoints. [#40047](https://github.com/electron/electron/pull/40047)
-- Added several properties to the `display` object including `detected`, `maximumCursorSize`, and `nativeOrigin`. [#40554](https://github.com/electron/electron/pull/40554) 
-- Added support for `ELECTRON_OZONE_PLATFORM_HINT` environment variable on Linux. [#39792](https://github.com/electron/electron/pull/39792) 
+- Added several properties to the `display` object including `detected`, `maximumCursorSize`, and `nativeOrigin`. [#40554](https://github.com/electron/electron/pull/40554)
+- Added support for `ELECTRON_OZONE_PLATFORM_HINT` environment variable on Linux. [#39792](https://github.com/electron/electron/pull/39792)
 
 ## End of Support for 25.x.y
 
 Electron 25.x.y has reached end-of-support as per the project's [support policy](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#version-support-policy). Developers and applications are encouraged to upgrade to a newer version of Electron.
 
-| E28 (Dec'23) | E29 (Feb'24) | E30 (Apr'24)
-| ------------ | ------------ | ------------
-| 28.x.y       | 29.x.y       | 30.x.y
-| 27.x.y       | 28.x.y       | 29.x.y
-| 26.x.y       | 27.x.y       | 28.x.y
+| E28 (Dec'23) | E29 (Feb'24) | E30 (Apr'24) |
+| ------------ | ------------ | ------------ |
+| 28.x.y       | 29.x.y       | 30.x.y       |
+| 27.x.y       | 28.x.y       | 29.x.y       |
+| 26.x.y       | 27.x.y       | 28.x.y       |
 
 ## What's Next
 

--- a/blog/electron-28-0.md
+++ b/blog/electron-28-0.md
@@ -1,0 +1,165 @@
+---
+title: Electron 28.0.0
+date: 2023-11-28T00:00:00.000Z
+authors:
+  - name: ckerr
+    url: 'https://github.com/ckerr'
+    image_url: 'https://github.com/ckerr.png?size=96'
+slug: electron-28-0
+---
+
+Electron 28.0.0 has been released! It includes upgrades to Chromium `120.0.6099.5`, V8 `12.0`, and Node.js `18.18.2`.
+
+---
+
+The Electron team is excited to announce the release of Electron 28.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://releases.electronjs.org/releases/stable). Continue reading for details about this release.
+
+If you have any feedback, please share it with us on [Twitter](https://twitter.com/electronjs) or [Mastodon](https://social.lfx.dev/@electronjs), or join our community [Discord](https://discord.com/invite/electronjs)! Bugs and feature requests can be reported in Electron's [issue tracker](https://github.com/electron/electron/issues).
+
+## Notable Changes
+
+### Stack Changes
+
+- Chromium `120.0.6099.5`
+    - New in [Chrome 119](https://developer.chrome.com/blog/new-in-chrome-119/) and in [DevTools 119](https://developer.chrome.com/blog/new-in-devtools-119/)
+    - New in [Chrome 120](https://developer.chrome.com/blog/new-in-chrome-120/) and in [DevTools 120](https://developer.chrome.com/blog/new-in-devtools-120/)
+* Node `18.18.2`
+    *  [Node 18.18.0 notes](https://nodejs.org/en/blog/release/v18.18.0/)
+    *  [Node 18.18.1 notes](https://nodejs.org/en/blog/release/v18.18.1/)
+    *  [Node 18.18.2 notes](https://nodejs.org/en/blog/release/v18.18.2/)
+* V8 `12.0`
+
+### Breaking Changes
+
+### Behavior Changed: `WebContents.backgroundThrottling` set to false affects all `WebContents` in the host `BrowserWindow`
+
+`WebContents.backgroundThrottling` set to false will disable frames throttling
+in the `BrowserWindow` for all `WebContents` displayed by it.
+
+### Removed: `BrowserWindow.setTrafficLightPosition(position)`
+
+`BrowserWindow.setTrafficLightPosition(position)` has been removed, the
+`BrowserWindow.setWindowButtonPosition(position)` API should be used instead
+which accepts `null` instead of `{ x: 0, y: 0 }` to reset the position to
+system default.
+
+```js
+// Removed in Electron 28
+win.setTrafficLightPosition({ x: 10, y: 10 })
+win.setTrafficLightPosition({ x: 0, y: 0 })
+
+// Replace with
+win.setWindowButtonPosition({ x: 10, y: 10 })
+win.setWindowButtonPosition(null)
+```
+
+### Removed: `BrowserWindow.getTrafficLightPosition()`
+
+`BrowserWindow.getTrafficLightPosition()` has been removed, the
+`BrowserWindow.getWindowButtonPosition()` API should be used instead
+which returns `null` instead of `{ x: 0, y: 0 }` when there is no custom
+position.
+
+```js
+// Removed in Electron 28
+const pos = win.getTrafficLightPosition()
+if (pos.x === 0 && pos.y === 0) {
+  // No custom position.
+}
+
+// Replace with
+const ret = win.getWindowButtonPosition()
+if (ret === null) {
+  // No custom position.
+}
+```
+
+### Removed: `ipcRenderer.sendTo()`
+
+The `ipcRenderer.sendTo()` API has been removed. It should be replaced by setting up a [`MessageChannel`](tutorial/message-ports.md#setting-up-a-messagechannel-between-two-renderers) between the renderers.
+
+The `senderId` and `senderIsMainFrame` properties of `IpcRendererEvent` have been removed as well.
+
+### Removed: `app.runningUnderRosettaTranslation`
+
+The `app.runningUnderRosettaTranslation` property has been removed.
+Use `app.runningUnderARM64Translation` instead.
+
+```js
+// Removed
+console.log(app.runningUnderRosettaTranslation)
+// Replace with
+console.log(app.runningUnderARM64Translation)
+```
+
+### Deprecated: `renderer-process-crashed` event on `app`
+
+The `renderer-process-crashed` event on `app` has been deprecated.
+Use the new `render-process-gone` event instead.
+
+```js
+// Deprecated
+app.on('renderer-process-crashed', (event, webContents, killed) => { /* ... */ })
+
+// Replace with
+app.on('render-process-gone', (event, webContents, details) => { /* ... */ })
+```
+
+### Deprecated: `params.inputFormType` property on `context-menu` on `WebContents`
+
+The `inputFormType` property of the params object in the `context-menu`
+event from `WebContents` has been deprecated. Use the new `formControlType`
+property instead.
+
+### Deprecated: `crashed` event on `WebContents` and `<webview>`
+
+The `crashed` events on `WebContents` and `<webview>` have been deprecated.
+Use the new `render-process-gone` event instead.
+
+```js
+// Deprecated
+win.webContents.on('crashed', (event, killed) => { /* ... */ })
+webview.addEventListener('crashed', (event) => { /* ... */ })
+
+// Replace with
+win.webContents.on('render-process-gone', (event, details) => { /* ... */ })
+webview.addEventListener('render-process-gone', (event) => { /* ... */ })
+```
+
+### Deprecated: `gpu-process-crashed` event on `app`
+
+The `gpu-process-crashed` event on `app` has been deprecated.
+Use the new `child-process-gone` event instead.
+
+```js
+// Deprecated
+app.on('gpu-process-crashed', (event, killed) => { /* ... */ })
+
+// Replace with
+app.on('child-process-gone', (event, details) => { /* ... */ })
+```
+
+### New Features
+
+- Added ESM support. For more details, see [the ESM limitations document](https://github.com/electron/electron/blob/main/docs/tutorial/esm-limitations.md). [#37535](https://github.com/electron/electron/pull/37535) 
+- The `UtilityProcess` API now supports ESM entrypoints. [#40047](https://github.com/electron/electron/pull/40047)
+- Added several properties to the `display` object including `detected`, `maximumCursorSize`, and `nativeOrigin`. [#40554](https://github.com/electron/electron/pull/40554) 
+- Added support for `ELECTRON_OZONE_PLATFORM_HINT` environment variable on Linux. [#39792](https://github.com/electron/electron/pull/39792) 
+
+## End of Support for 25.x.y
+
+Electron 25.x.y has reached end-of-support as per the project's [support policy](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#version-support-policy). Developers and applications are encouraged to upgrade to a newer version of Electron.
+
+| E28 (Dec'23) | E29 (Feb'24) | E30 (Apr'24)
+| ------------ | ------------ | ------------
+| 28.x.y       | 29.x.y       | 30.x.y
+| 27.x.y       | 28.x.y       | 29.x.y
+| 26.x.y       | 27.x.y       | 28.x.y
+
+## What's Next
+
+In the short term, you can expect the team to continue to focus on keeping up with the development of the major components that make up Electron, including Chromium, Node, and V8.
+
+You can find [Electron's public timeline here](https://www.electronjs.org/docs/latest/tutorial/electron-timelines).
+
+More information about future changes can be found on the [Planned Breaking Changes](https://github.com/electron/electron/blob/main/docs/breaking-changes.md) page.

--- a/blog/electron-28-0.md
+++ b/blog/electron-28-0.md
@@ -37,7 +37,7 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 ### New Features
 
 - Enabled ESM support. [#37535](https://github.com/electron/electron/pull/37535)
-  - For more details, see the [ESM documentation](https://github.com/electron/electron/blob/main/docs/tutorial/esm.md).
+  - For more details, see the [ESM documentation](https://www.electronjs.org/docs/latest/tutorial/esm).
 - Added ESM entrypoints to the `UtilityProcess` API. [#40047](https://github.com/electron/electron/pull/40047)
 - Added several properties to the `display` object including `detected`, `maximumCursorSize`, and `nativeOrigin`. [#40554](https://github.com/electron/electron/pull/40554)
 - Added support for `ELECTRON_OZONE_PLATFORM_HINT` environment variable on Linux. [#39792](https://github.com/electron/electron/pull/39792)

--- a/blog/electron-28-0.md
+++ b/blog/electron-28-0.md
@@ -31,12 +31,12 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 
 ### Breaking Changes
 
-### Behavior Changed: `WebContents.backgroundThrottling` set to false affects all `WebContents` in the host `BrowserWindow`
+#### Behavior Changed: `WebContents.backgroundThrottling` set to false affects all `WebContents` in the host `BrowserWindow`
 
 `WebContents.backgroundThrottling` set to false will disable frames throttling
 in the `BrowserWindow` for all `WebContents` displayed by it.
 
-### Removed: `BrowserWindow.setTrafficLightPosition(position)`
+#### Removed: `BrowserWindow.setTrafficLightPosition(position)`
 
 `BrowserWindow.setTrafficLightPosition(position)` has been removed, the
 `BrowserWindow.setWindowButtonPosition(position)` API should be used instead
@@ -53,7 +53,7 @@ win.setWindowButtonPosition({ x: 10, y: 10 })
 win.setWindowButtonPosition(null)
 ```
 
-### Removed: `BrowserWindow.getTrafficLightPosition()`
+#### Removed: `BrowserWindow.getTrafficLightPosition()`
 
 `BrowserWindow.getTrafficLightPosition()` has been removed, the
 `BrowserWindow.getWindowButtonPosition()` API should be used instead
@@ -74,13 +74,13 @@ if (ret === null) {
 }
 ```
 
-### Removed: `ipcRenderer.sendTo()`
+#### Removed: `ipcRenderer.sendTo()`
 
 The `ipcRenderer.sendTo()` API has been removed. It should be replaced by setting up a [`MessageChannel`](tutorial/message-ports.md#setting-up-a-messagechannel-between-two-renderers) between the renderers.
 
 The `senderId` and `senderIsMainFrame` properties of `IpcRendererEvent` have been removed as well.
 
-### Removed: `app.runningUnderRosettaTranslation`
+#### Removed: `app.runningUnderRosettaTranslation`
 
 The `app.runningUnderRosettaTranslation` property has been removed.
 Use `app.runningUnderARM64Translation` instead.
@@ -90,53 +90,6 @@ Use `app.runningUnderARM64Translation` instead.
 console.log(app.runningUnderRosettaTranslation)
 // Replace with
 console.log(app.runningUnderARM64Translation)
-```
-
-### Deprecated: `renderer-process-crashed` event on `app`
-
-The `renderer-process-crashed` event on `app` has been deprecated.
-Use the new `render-process-gone` event instead.
-
-```js
-// Deprecated
-app.on('renderer-process-crashed', (event, webContents, killed) => { /* ... */ })
-
-// Replace with
-app.on('render-process-gone', (event, webContents, details) => { /* ... */ })
-```
-
-### Deprecated: `params.inputFormType` property on `context-menu` on `WebContents`
-
-The `inputFormType` property of the params object in the `context-menu`
-event from `WebContents` has been deprecated. Use the new `formControlType`
-property instead.
-
-### Deprecated: `crashed` event on `WebContents` and `<webview>`
-
-The `crashed` events on `WebContents` and `<webview>` have been deprecated.
-Use the new `render-process-gone` event instead.
-
-```js
-// Deprecated
-win.webContents.on('crashed', (event, killed) => { /* ... */ })
-webview.addEventListener('crashed', (event) => { /* ... */ })
-
-// Replace with
-win.webContents.on('render-process-gone', (event, details) => { /* ... */ })
-webview.addEventListener('render-process-gone', (event) => { /* ... */ })
-```
-
-### Deprecated: `gpu-process-crashed` event on `app`
-
-The `gpu-process-crashed` event on `app` has been deprecated.
-Use the new `child-process-gone` event instead.
-
-```js
-// Deprecated
-app.on('gpu-process-crashed', (event, killed) => { /* ... */ })
-
-// Replace with
-app.on('child-process-gone', (event, details) => { /* ... */ })
 ```
 
 ### New Features

--- a/blog/electron-28-0.md
+++ b/blog/electron-28-0.md
@@ -18,13 +18,16 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 
 ## Notable Changes
 
+## Highlights
+
+- Implemented support for EcmaScript Modules ESM support. This includes support for ESM in Electron proper, as well as areas such as the `UtilityProcess` API entrypoints. See [#37535](https://github.com/electron/electron/pull/37535). and [#40047](https://github.com/electron/electron/pull/40047) for more details
+- In addition to enabling ESM support in Electron itself, Electron Forge also supports using ESM to package, build and develop Electron applications. You can find this support in [Forge v7.0.0](https://github.com/electron/forge/releases/tag/v7.0.0) or higher.
+
 ### Stack Changes
 
 - Chromium `120.0.6099.56`
-
   - New in [Chrome 119](https://developer.chrome.com/blog/new-in-chrome-119/) and in [DevTools 119](https://developer.chrome.com/blog/new-in-devtools-119/)
   - New in [Chrome 120](https://developer.chrome.com/blog/new-in-chrome-120/) and in [DevTools 120](https://developer.chrome.com/blog/new-in-devtools-120/)
-
 - Node `18.18.2`
   - [Node 18.18.0 notes](https://nodejs.org/en/blog/release/v18.18.0/)
   - [Node 18.18.1 notes](https://nodejs.org/en/blog/release/v18.18.1/)
@@ -35,11 +38,9 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 
 - Enabled ESM support. [#37535](https://github.com/electron/electron/pull/37535)
   - For more details, see the [ESM documentation](https://github.com/electron/electron/blob/main/docs/tutorial/esm.md).
-- The `UtilityProcess` API now supports ESM entrypoints. [#40047](https://github.com/electron/electron/pull/40047)
+- Added ESM entrypoints to the `UtilityProcess` API. [#40047](https://github.com/electron/electron/pull/40047)
 - Added several properties to the `display` object including `detected`, `maximumCursorSize`, and `nativeOrigin`. [#40554](https://github.com/electron/electron/pull/40554)
 - Added support for `ELECTRON_OZONE_PLATFORM_HINT` environment variable on Linux. [#39792](https://github.com/electron/electron/pull/39792)
-
-In addition to enabling ESM support in Electron itself, Electron Forge also supports using ESM to package, build and develop Electron applications. You can find this support in Forge v7.0.0 or higher: https://github.com/electron/forge/releases/tag/v7.0.0
 
 ### Breaking Changes
 


### PR DESCRIPTION
This PR adds a new blog post for Electron 28.
@electron/wg-releases, @electron/wg-outreach 

Merge target: December 5th, after 28.0.0 releases.

⚠️ Do not merge until the following are completed ⚠️

- [x]  update node, v8 and chromium versions from final chrome roll under Stack Changes section
- [x]  edit link for M120 "New In Chrome" blog post
- [x]  add a few bullets for New Features section
- [x]  add any missing items in Breaking Changes section
- [x]  update End of Support
