### PR TITLE
docs: update E28 blog post date

### DIFF
--- a/blog/electron-28-0.md
+++ b/blog/electron-28-0.md
@@ -1,6 +1,6 @@
 ---
 title: Electron 28.0.0
-date: 2023-11-28T00:00:00.000Z
+date: 2023-12-06T00:00:00.000Z
 authors:
   - name: ckerr
     url: 'https://github.com/ckerr'


### PR DESCRIPTION
This wasn't published until 2023-12-06 and with the original date it sorts below an older blog post, which is confusing.