### PR TITLE
fix: link to MessageChannel in v28 blog post

### DIFF
--- a/blog/electron-28-0.md
+++ b/blog/electron-28-0.md
@@ -89,7 +89,7 @@ if (ret === null) {
 
 #### Removed: `ipcRenderer.sendTo()`
 
-The `ipcRenderer.sendTo()` API has been removed. It should be replaced by setting up a [`MessageChannel`](tutorial/message-ports.md#setting-up-a-messagechannel-between-two-renderers) between the renderers.
+The `ipcRenderer.sendTo()` API has been removed. It should be replaced by setting up a [`MessageChannel`](https://www.electronjs.org/docs/latest/tutorial/message-ports#setting-up-a-messagechannel-between-two-renderers) between the renderers.
 
 The `senderId` and `senderIsMainFrame` properties of `IpcRendererEvent` have been removed as well.
 


### PR DESCRIPTION
We should look into automation around this, we tend to end up with broken links like these in blog posts.