### PR TITLE
chore: add cjs and mjs aliases for code block syntax highlighting

### DIFF
--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -1,0 +1,24 @@
+import siteConfig from '@generated/docusaurus.config';
+
+export default function prismIncludeLanguages(PrismObject) {
+  const {
+    themeConfig: { prism },
+  } = siteConfig;
+  const { additionalLanguages } = prism;
+  // Prism components work on the Prism instance on the window, while prism-
+  // react-renderer uses its own Prism instance. We temporarily mount the
+  // instance onto window, import components to enhance it, then remove it to
+  // avoid polluting global namespace.
+  // You can mutate PrismObject: registering plugins, deleting languages... As
+  // long as you don't re-assign it
+  globalThis.Prism = PrismObject;
+  additionalLanguages.forEach((lang) => {
+    require(`prismjs/components/prism-${lang}`);
+  });
+
+  // Add JavaScript aliases
+  PrismObject.languages.mjs = PrismObject.languages.cjs =
+    PrismObject.languages.javascript;
+
+  delete globalThis.Prism;
+}


### PR DESCRIPTION
This is in preparation of upstream docs in `e/e` making usage of `cjs` and `mjs` language identifiers in code blocks. Need to add them as aliases for JS so they get syntax highlighting on Docusaurus.

The code changes are a result of [following the official docs](https://docusaurus.io/docs/markdown-features/code-blocks#supported-languages) and running `yarn swizzle @docusaurus/theme-classic prism-include-languages`, then adding the aliases.