### PR TITLE
ci: update perms for workflow jobs

### DIFF
--- a/.github/workflows/update-docs-branch.yml
+++ b/.github/workflows/update-docs-branch.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag: v3.3.0
       - name: 'Switch branches'

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag: v3.3.0
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # tag: v3.6.0


### PR DESCRIPTION
The default permissions for `GITHUB_TOKEN` have changed, so update these.