### PR TITLE
ci: add problem matcher for Docusaurus output

### DIFF
--- a/.github/problem-matchers/docusaurus.json
+++ b/.github/problem-matchers/docusaurus.json
@@ -1,0 +1,14 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "docusaurus",
+      "pattern": [
+        {
+          "regexp": "^\\[(WARNING)\\] (.*)$",
+          "severity": 1,
+          "message": 2
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -54,6 +54,8 @@ jobs:
       - name: Rewrite docs paths if version branch
         if: ${{ inputs.branch == 'version' }}
         run: node scripts/build-as-doc-version.js $(GIT_BRANCH)
+      - name: Add Docusaurus problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/docusaurus.json"
       - name: Build default locale site
         run: yarn build
         env:

--- a/.github/workflows/update-i18n-deploy.yml
+++ b/.github/workflows/update-i18n-deploy.yml
@@ -38,6 +38,9 @@ jobs:
       #   env:
       #     SAS: ${{ secrets.SAS }}
 
+      - name: Add Docusaurus problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/docusaurus.json"
+
       - name: Build
         run: yarn i18n:build
 


### PR DESCRIPTION
Adds a problem matcher to turn warnings in the Docusaurus build output into warning annotations on the workflow runs so they're more discoverable, and org-wide automation can pick them up.