### PR TITLE
ci: bump missed workflow to Node.js v20

### DIFF
--- a/.github/workflows/update-i18n-deploy.yml
+++ b/.github/workflows/update-i18n-deploy.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # tag: v3.6.0
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Install dependencies
         uses: bahmutov/npm-install@8add8c6d2c8586964896d9fdc639e021312a643f # tag: v1.8.28


### PR DESCRIPTION
Follow-up to #494, we missed one workflow.