### PR TITLE
fix: correct download link for Fiddle arm7l AppImage

### DIFF
--- a/src/pages/fiddle/index.tsx
+++ b/src/pages/fiddle/index.tsx
@@ -43,7 +43,7 @@ export default function FiddlePage() {
       appimage: {
         x64: `https://github.com/electron/fiddle/releases/download/v${version}/Electron.Fiddle-${version}-x64.AppImage`,
         arm64: `https://github.com/electron/fiddle/releases/download/v${version}/Electron.Fiddle-${version}-arm64.AppImage`,
-        arm7l: `https://github.com/electron/fiddle/releases/download/v${version}/Electron.Fiddle-${version}-armv7hl.AppImage`,
+        arm7l: `https://github.com/electron/fiddle/releases/download/v${version}/Electron.Fiddle-${version}-armv7l.AppImage`,
       },
     },
   };


### PR DESCRIPTION
This has always been incorrect, I believe.