### PR TITLE
fix(blog): remove outdated CSS syntax

### DIFF
--- a/blog/august-2016-roundup.md
+++ b/blog/august-2016-roundup.md
@@ -18,8 +18,6 @@ If you've made an Electron app or host a meetup, make a [pull request](https://g
 
 ### New Apps
 
-{: .table .table-ruled .table-full-width .table-with-spacious-first-column .mb-7}
-
 |                                                                        |                                                                                 |                                                                                                |
 | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | <img src='/images/apps/coderpgify.png' width='50'/>                    | [Code RPGify](http://code.rpgify.com)                                           | RPG style coding application                                                                   |

--- a/blog/electron-37.md
+++ b/blog/electron-37.md
@@ -51,7 +51,7 @@ document.body.style.setProperty('--awesome-color', 'orange');
 
 The variable values can be also edited from the **Styles** section of the development tools for quick feedback and tweaks:
 
-![CSS properties in Styles tab](https://cloud.githubusercontent.com/assets/671378/13991612/1d10eb9c-f0d6-11e5-877b-c4dbc59f1209.gif){: .screenshot }
+![CSS properties in Styles tab](https://cloud.githubusercontent.com/assets/671378/13991612/1d10eb9c-f0d6-11e5-877b-c4dbc59f1209.gif)
 
 ### `KeyboardEvent.code` Property
 

--- a/blog/july-2016-roundup.md
+++ b/blog/july-2016-roundup.md
@@ -18,22 +18,21 @@ If you've made an Electron app or host a meetup, make a [pull request](https://g
 
 ### New Apps
 
-{: .table .table-ruled .table-full-width .table-with-spacious-first-column .mb-7}
-| | | |
-| --- | --- | -- |
-| <img src="/images/apps/demio.png" width="50"/> | [Demio](https://demio.com) | A Webinar platform built for inbound sales and marketing |
-| <img src="/images/apps/electorrent.png" width="50"/> | [Electorrent](https://github.com/Tympanix/Electorrent) | A remote client app for uTorrent server |
-| <img src="/images/apps/phonegap.png" width="50"/> | [PhoneGap](http://phonegap.com/products/#desktop-app-section) | The open source framework that gets you building amazing mobile apps using web technology |
-| <img src="/images/apps/wordmark.png" width="50"/> | [WordMark](http://wordmarkapp.com) | A lightweight blog publishing editor for Markdown writers |
-| <img src="/images/apps/ubauth.png" width="50"/> | [UbAuth](http://ubauth.enytc.com) | App to help developers create access tokens for Uber applications with OAuth 2.0 |
-| <img src="/images/apps/hyperterm.png" width="50"/> | [HyperTerm](https://hyperterm.org) | HTML/JS/CSS terminal |
-| <img src="/images/apps/marp.png" width="50"/> | [Marp](https://yhatt.github.io/marp) | Markdown presentation writer |
-| <img src="/images/apps/glyphrstudio.png" width="50"/> | [Glyphr Studio](https://github.com/glyphr-studio/Glyphr-Studio-Desktop) | A free, web based font designer, focusing on font design for hobbyists |
-| <img src="/images/apps/bitcrypt.png" width="50"/> | [BitCrypt](https://github.com/Nazgul07/BitCrypt) | A simple file encryption application for Windows Encrypt your bits |
-| <img src="/images/apps/trym.png" width="50"/> | [Trym](http://kontentapps.com/trym) | Beautiful small app for macOS to help you view, optimize and convert SVG icons |
-| <img src="/images/apps/booker.png" width="50"/> | [Booker](http://apps.meamka.me/booker) | Text editor with the power of Markdown |
-| <img src="/images/apps/phonepresenter.png" width="50"/> | [PhonePresenter](https://phonepresenter.com) | The smartest presentation clicker |
-| <img src="/images/apps/yout-player.png" width="50"/> | [Yout](https://youtplayer.github.io) | The new way to watch your playlists from YouTube on desktop |
+|                                                         |                                                                         |                                                                                           |
+| ------------------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| <img src="/images/apps/demio.png" width="50"/>          | [Demio](https://demio.com)                                              | A Webinar platform built for inbound sales and marketing                                  |
+| <img src="/images/apps/electorrent.png" width="50"/>    | [Electorrent](https://github.com/Tympanix/Electorrent)                  | A remote client app for uTorrent server                                                   |
+| <img src="/images/apps/phonegap.png" width="50"/>       | [PhoneGap](http://phonegap.com/products/#desktop-app-section)           | The open source framework that gets you building amazing mobile apps using web technology |
+| <img src="/images/apps/wordmark.png" width="50"/>       | [WordMark](http://wordmarkapp.com)                                      | A lightweight blog publishing editor for Markdown writers                                 |
+| <img src="/images/apps/ubauth.png" width="50"/>         | [UbAuth](http://ubauth.enytc.com)                                       | App to help developers create access tokens for Uber applications with OAuth 2.0          |
+| <img src="/images/apps/hyperterm.png" width="50"/>      | [HyperTerm](https://hyperterm.org)                                      | HTML/JS/CSS terminal                                                                      |
+| <img src="/images/apps/marp.png" width="50"/>           | [Marp](https://yhatt.github.io/marp)                                    | Markdown presentation writer                                                              |
+| <img src="/images/apps/glyphrstudio.png" width="50"/>   | [Glyphr Studio](https://github.com/glyphr-studio/Glyphr-Studio-Desktop) | A free, web based font designer, focusing on font design for hobbyists                    |
+| <img src="/images/apps/bitcrypt.png" width="50"/>       | [BitCrypt](https://github.com/Nazgul07/BitCrypt)                        | A simple file encryption application for Windows Encrypt your bits                        |
+| <img src="/images/apps/trym.png" width="50"/>           | [Trym](http://kontentapps.com/trym)                                     | Beautiful small app for macOS to help you view, optimize and convert SVG icons            |
+| <img src="/images/apps/booker.png" width="50"/>         | [Booker](http://apps.meamka.me/booker)                                  | Text editor with the power of Markdown                                                    |
+| <img src="/images/apps/phonepresenter.png" width="50"/> | [PhonePresenter](https://phonepresenter.com)                            | The smartest presentation clicker                                                         |
+| <img src="/images/apps/yout-player.png" width="50"/>    | [Yout](https://youtplayer.github.io)                                    | The new way to watch your playlists from YouTube on desktop                               |
 
 ### New Meetups
 


### PR DESCRIPTION
I don't think we support this syntax on the website at all anymore (e.g. https://www.electronjs.org/blog/august-2016-roundup), and MDX 3 will explicitly require us to escape these characters in the copy.