### PR TITLE
fix: Navbar carets should never appear on a separate line (#369)

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -32,6 +32,7 @@
   // custom vars
   --electron-heading: var(--electron-color-mid);
   --electron-inline-code: var(--electron-color-secondary-mid);
+  --ifm-navbar-item-padding-horizontal: 8px;
 
   // docusaurus variables
   --ifm-hover-overlay: rgba(162, 236, 251, 0.2);


### PR DESCRIPTION
  --ifm-navbar-item-padding-horizontal variable was never assigned a value

Fixes #369 