### PR TITLE
chore: delete unused versions-info.json

### DIFF
--- a/versions-info.json
+++ b/versions-info.json
@@ -1,7 +1,0 @@
-[
-  {
-    "label": "22-x-y",
-    "href": "https://electronjs.org/docs/latest",
-    "target": "_blank"
-  }
-]


### PR DESCRIPTION
Don't think we use this anymore. It points to 22-x-y and there's no way that's relevant. :) 