### PR TITLE
fix: opposite event description in blog

### DIFF
--- a/blog/electron-18.md
+++ b/blog/electron-18.md
@@ -39,7 +39,7 @@ Additionally, Electron has changed supported versions from latest three versions
 - Removed the old `BrowserWindowProxy`-based implementation of `window.open`. This also removes the `nativeWindowOpen` option from `webPreferences`. [#29405](https://github.com/electron/electron/pull/29405)
 - Added 'focus' and 'blur' events to `WebContents`. [#25873](https://github.com/electron/electron/pull/25873)
 - Added Substitutions menu roles on macOS: `showSubstitutions`, `toggleSmartQuotes`, `toggleSmartDashes`, `toggleTextReplacement`. [#32024](https://github.com/electron/electron/pull/32024)
-- Added `first-instance-ack` event to the `app.requestSingleInstanceLock()` flow, so that users can pass some data back from the second instance to the first instance. [#31460](https://github.com/electron/electron/pull/31460)
+- Added a `first-instance-ack` event to the `app.requestSingleInstanceLock()` flow, allowing users to seamlessly transmit data from the first instance to the second instance. [#31460](https://github.com/electron/electron/pull/31460)
 - Added support for more color formats in `setBackgroundColor`. [#33364](https://github.com/electron/electron/pull/33364)
 
 See the [18.0.0 release notes](https://github.com/electron/electron/releases/tag/v18.0.0) for a full list of new features and changes.


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/website/blob/main/docs/latest/development/pull-requests.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Fixes #229
Refactored feature highlight for `first-instance-ack` according to [#31460](https://github.com/electron/electron/pull/31460).