### PR TITLE
fix: macOS download links for Fiddle v0.36.2

### DIFF
--- a/src/pages/fiddle/index.tsx
+++ b/src/pages/fiddle/index.tsx
@@ -9,7 +9,7 @@ import LinuxLogo from '@site/static/assets/img/platform-linux.svg';
 import clsx from 'clsx';
 
 import { usePluginData } from '@docusaurus/useGlobalData';
-import { SemVer, satisfies } from 'semver';
+import { SemVer } from 'semver';
 
 export default function FiddlePage() {
   const [OS, setOS] = useState('win32');

--- a/src/pages/fiddle/index.tsx
+++ b/src/pages/fiddle/index.tsx
@@ -49,14 +49,6 @@ export default function FiddlePage() {
     },
   };
 
-  // Handle a temporary Forge naming issue that replaced the period in "Electron.Fiddle" with
-  // a hyphen in the 0.36.0 release. We expect that 0.37 and onwards will have a fix. Once
-  // released, this code can be removed.
-  if (satisfies(version, '^0.36.0')) {
-    downloadLinks.darwin.x64 = `${downloadPrefix}/Electron-Fiddle-darwin-x64-${version}.zip`;
-    downloadLinks.darwin.arm64 = `${downloadPrefix}/Electron-Fiddle-darwin-arm64-${version}.zip`;
-  }
-
   const renderDownloadButtons = () => {
     switch (OS) {
       case 'win32':


### PR DESCRIPTION
Fixes https://github.com/electron/fiddle/issues/1571

We tried to make this self-healing in #507 but the next release ended up being v0.36.2 instead of v0.37.0 (no features 🤷) so this didn't end up working as we'd hoped. The "Check Download Links" scheduled job on the Fiddle repo [ended up catching it as intended](https://github.com/electron/fiddle/actions/runs/8384059849).