### PR TITLE
fix: Add height and width specification to navbar logo

### DIFF
--- a/docusaurusConfig.ts
+++ b/docusaurusConfig.ts
@@ -46,6 +46,8 @@ const config: Config = {
       logo: {
         alt: 'Electron homepage',
         src: 'assets/img/logo.svg',
+        width: 32,
+        height: 32,
       },
       items: [
         {


### PR DESCRIPTION
Resolving https://github.com/electron/website/issues/539 by adding height and width specification to navbar logo. 

Discussion here: https://github.com/electron/website/issues/539#issuecomment-2021281903