### PR TITLE
ci: fix docs update workflow

### DIFF
--- a/.github/workflows/update-docs-branch.yml
+++ b/.github/workflows/update-docs-branch.yml
@@ -3,6 +3,16 @@ name: 'Update docs branch'
 on:
   repository_dispatch:
     types: [doc_changes_branches]
+  workflow_dispatch:
+    inputs:
+      branch:
+        type: string
+        description: The branch of the commit, usually something like `15-x-y`
+        required: true
+      sha:
+        type: string
+        description: The SHA of the `electron/electron` commit
+        required: true
 
 permissions: {}
 
@@ -21,7 +31,7 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
       - name: Switch branches
         # We switch to the version branch or create a new one if needed
-        run: git fetch origin && git checkout -t origin/v${{ github.event.client_payload.branch}} || git checkout -b v${{ github.event.client_payload.branch}}
+        run: git fetch origin && git checkout -t origin/v${{ github.event.client_payload.branch || github.event.inputs.branch }} || git checkout -b v${{ github.event.client_payload.branch || github.event.inputs.branch }}
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # tag: v4.0.2
         with:
           node-version: 20
@@ -29,7 +39,7 @@ jobs:
         uses: bahmutov/npm-install@237ded403e6012a48281f4572eab0c8eafe55b3f # tag: v1.10.1
       - name: Prebuild
         run: |
-          'yarn pre-build ${{ github.event.client_payload.sha }}'
+          yarn pre-build ${{ github.event.client_payload.sha || github.event.inputs.sha }}
           git add .
       - name: Push changes
         uses: dsanders11/github-app-commit-action@48d2ff8c1a855eb15d16afa97ae12616456d7cbc # v1.4.0

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -3,6 +3,16 @@ name: 'Update docs'
 on:
   repository_dispatch:
     types: [doc_changes]
+  workflow_dispatch:
+    inputs:
+      branch:
+        type: string
+        description: The branch of the commit, usually something like `15-x-y`
+        required: true
+      sha:
+        type: string
+        description: The SHA of the `electron/electron` commit
+        required: true
 
 permissions: {}
 
@@ -26,7 +36,7 @@ jobs:
         uses: bahmutov/npm-install@237ded403e6012a48281f4572eab0c8eafe55b3f # tag: v1.10.1
       - name: Prebuild
         run: |
-          'yarn pre-build ${{ github.event.client_payload.sha }} ${{ github.event.client_payload.branch}}'
+          yarn pre-build ${{ github.event.client_payload.sha || github.event.inputs.sha }} ${{ github.event.client_payload.branch || github.event.inputs.branch }}
           git add .
       - name: Push changes
         uses: dsanders11/github-app-commit-action@48d2ff8c1a855eb15d16afa97ae12616456d7cbc # v1.4.0


### PR DESCRIPTION
Fixes the workflow after #533 which accidentally broke it by not removing the single quotes around `yarn pre-build` when changing to multi-line.

Also updates the workflow to work with manual runs via `workflow_dispatch` so that we can easily re-run any failures.