### PR TITLE
docs: add Electron 30 blog post

### DIFF
--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -40,7 +40,7 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
   - [Node 20.11.1 notes](https://nodejs.org/en/blog/release/v20.11.1/)
 - V8 `12.4`
 
-Electron 29 upgrades Chromium from `122.0.6261.39` to `124.0.6367.49`, Node from `20.9.0` to `20.11.1`, and V8 from `12.2` to `12.4`.
+Electron 30 upgrades Chromium from `122.0.6261.39` to `124.0.6367.49`, Node from `20.9.0` to `20.11.1`, and V8 from `12.2` to `12.4`.
 
 ### Breaking Changes
 

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -45,10 +45,10 @@ Electron 30 upgrades Chromium from `122.0.6261.39` to `124.0.6367.49`, Node from
 ### New Features
 
 - Added a `transparent` webpreference to webviews. ([#40301](https://github.com/electron/electron/pull/40301))
-- Added a new instance property `navigationHistory` on webContents API with `navigationHistory.getEntryAtIndex` method, enabling applications to retrieve the URL and title of any navigation entry within the browsing history. ([#41662](https://github.com/electron/electron/pull/41662)) <span style="font-size:small;">(Also in [29](https://github.com/electron/electron/pull/41661))</span>
+- Added a new instance property `navigationHistory` on webContents API with `navigationHistory.getEntryAtIndex` method, enabling applications to retrieve the URL and title of any navigation entry within the browsing history. ([#41662](https://github.com/electron/electron/pull/41662))
 - Added new `BrowserWindow.isOccluded()` method to allow apps to check occlusion status. ([#38982](https://github.com/electron/electron/pull/38982))
-- Added proxy configuring support for requests made with the `net` module from the utility process. ([#41417](https://github.com/electron/electron/pull/41417)) <span style="font-size:small;">(Also in [28](https://github.com/electron/electron/pull/41744), [29](https://github.com/electron/electron/pull/41416))</span>
-- Added support for Bluetooth ports being requested by service class ID in `navigator.serial`. ([#41734](https://github.com/electron/electron/pull/41734)) <span style="font-size:small;">(Also in [29](https://github.com/electron/electron/pull/41735))</span>
+- Added proxy configuring support for requests made with the `net` module from the utility process. ([#41417](https://github.com/electron/electron/pull/41417))
+- Added support for Bluetooth ports being requested by service class ID in `navigator.serial`. ([#41734](https://github.com/electron/electron/pull/41734))
 - Added support for the Node.js [`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile) CLI flag. ([#41822](https://github.com/electron/electron/pull/41822))
 
 ### Breaking Changes

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -23,12 +23,13 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 
 ### Highlights
 
-- ASAR Integrity fuse now supported on Windows [#40504](https://github.com/electron/electron/pull/40504)
+- ASAR Integrity fuse now supported on Windows ([#40504](https://github.com/electron/electron/pull/40504))
   - Existing apps with ASAR Integrity enabled may not work on Windows if not configured correctly. Apps using Electron packaging tools should upgrade to `@electron/packager@18.3.1` or `@electron/forge@7.4.0`.
   - Take a look at our [ASAR Integrity tutorial](https://www.electronjs.org/docs/latest/tutorial/asar-integrity) for more information.
-- Added `WebContentsView` and `BaseWindow`, deprecating & replacing `BrowserView` [#35658](https://github.com/electron/electron/pull/35658)
-- Added `net` module to utility process [#40017](https://github.com/electron/electron/pull/40017)
-- Implemented support for the File System API [#41827](https://github.com/electron/electron/commit/cf1087badd437906f280373decb923733a8523e6)
+- Added `WebContentsView` and `BaseWindow`, deprecating & replacing `BrowserView` ([#35658](https://github.com/electron/electron/pull/35658))
+  - See [our Web Embeds documentation](https://www.electronjs.org/docs/latest/tutorial/web-embeds) for a comparison of the new `WebContentsView` API to other similar APIs.
+- Added `net` module to utility process ([#40017](https://github.com/electron/electron/pull/40017))
+- Implemented support for the [File System API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API) ([#41827](https://github.com/electron/electron/commit/cf1087badd437906f280373decb923733a8523e6))
 
 ### Stack Changes
 

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -26,7 +26,7 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 - ASAR Integrity fuse now supported on Windows ([#40504](https://github.com/electron/electron/pull/40504))
   - Existing apps with ASAR Integrity enabled may not work on Windows if not configured correctly. Apps using Electron packaging tools should upgrade to `@electron/packager@18.3.1` or `@electron/forge@7.4.0`.
   - Take a look at our [ASAR Integrity tutorial](https://www.electronjs.org/docs/latest/tutorial/asar-integrity) for more information.
-- Added `WebContentsView` and `BaseWindow`, deprecating & replacing `BrowserView` ([#35658](https://github.com/electron/electron/pull/35658))
+- Added [`WebContentsView`](https://www.electronjs.org/docs/latest/api/web-contents-view) and [`BaseWindow`](https://www.electronjs.org/docs/latest/api/base-window) main process modules, deprecating & replacing `BrowserView` ([#35658](https://github.com/electron/electron/pull/35658))
   - See [our Web Embeds documentation](https://www.electronjs.org/docs/latest/tutorial/web-embeds) for a comparison of the new `WebContentsView` API to other similar APIs.
 - Added [`net`](https://www.electronjs.org/docs/latest/api/net) module to utility process ([#40017](https://github.com/electron/electron/pull/40017))
 - Implemented support for the [File System API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API) ([#41827](https://github.com/electron/electron/commit/cf1087badd437906f280373decb923733a8523e6))

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -27,6 +27,7 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
   - Existing apps with ASAR Integrity enabled may not work on Windows if not configured correctly. Apps using Electron packaging tools should upgrade to `@electron/packager@18.3.1` or `@electron/forge@7.4.0`.
   - Take a look at our [ASAR Integrity tutorial](https://www.electronjs.org/docs/latest/tutorial/asar-integrity) for more information.
 - Added [`WebContentsView`](https://www.electronjs.org/docs/latest/api/web-contents-view) and [`BaseWindow`](https://www.electronjs.org/docs/latest/api/base-window) main process modules, deprecating & replacing `BrowserView` ([#35658](https://github.com/electron/electron/pull/35658))
+  - `BrowserView` is now a shim over `WebContentsView` and the old implementation has been removed.
   - See [our Web Embeds documentation](https://www.electronjs.org/docs/latest/tutorial/web-embeds) for a comparison of the new `WebContentsView` API to other similar APIs.
 - Added [`net`](https://www.electronjs.org/docs/latest/api/net) module to utility process ([#40017](https://github.com/electron/electron/pull/40017))
 - Implemented support for the [File System API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API) ([#41827](https://github.com/electron/electron/commit/cf1087badd437906f280373decb923733a8523e6))

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -23,12 +23,12 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 
 ### Highlights
 
-* ASAR Integrity fuse now supported on Windows
+* ASAR Integrity fuse now supported on Windows [#40504](https://github.com/electron/electron/pull/40504)
   * Existing apps with ASAR Integrity enabled may not work on Windows if not configured correctly.
   * Take a look at our [ASAR Integrity tutorial](https://www.electronjs.org/docs/latest/tutorial/asar-integrity) for more information.
-* Added `WebContentsView` and `BaseWindow`, deprecating & replacing `BrowserView`
-* Added `net` module to utility process
-* Implemented support for the File System API
+* Added `WebContentsView` and `BaseWindow`, deprecating & replacing `BrowserView` [#35658](https://github.com/electron/electron/pull/35658)
+* Added `net` module to utility process [#40017](https://github.com/electron/electron/pull/40017)
+* Implemented support for the File System API [#41827](https://github.com/electron/electron/commit/cf1087badd437906f280373decb923733a8523e6)
 
 ### Stack Changes
 

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -24,7 +24,7 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 ### Highlights
 
 - ASAR Integrity fuse now supported on Windows [#40504](https://github.com/electron/electron/pull/40504)
-  - Existing apps with ASAR Integrity enabled may not work on Windows if not configured correctly.
+  - Existing apps with ASAR Integrity enabled may not work on Windows if not configured correctly. Apps using Electron packaging tools should upgrade to `@electron/packager@18.3.1` or `@electron/forge@7.4.0`.
   - Take a look at our [ASAR Integrity tutorial](https://www.electronjs.org/docs/latest/tutorial/asar-integrity) for more information.
 - Added `WebContentsView` and `BaseWindow`, deprecating & replacing `BrowserView` [#35658](https://github.com/electron/electron/pull/35658)
 - Added `net` module to utility process [#40017](https://github.com/electron/electron/pull/40017)
@@ -51,9 +51,9 @@ attribute in order to access them.
 See [documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#allow) for
 more information.
 
-#### Removed: The `--disable-color-correct-rendering` switch
+#### Removed: The `--disable-color-correct-rendering` command line switch
 
-This switch was never formally documented but it's removal is being noted here regardless. Chromium itself now has better support for color spaces so this flag should not be needed.
+This switch was never formally documented but its removal is being noted here regardless. Chromium itself now has better support for color spaces so this flag should not be needed.
 
 #### Behavior Changed: `BrowserView.setAutoResize` behavior on macOS
 

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -29,7 +29,6 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 - Added [`WebContentsView`](https://www.electronjs.org/docs/latest/api/web-contents-view) and [`BaseWindow`](https://www.electronjs.org/docs/latest/api/base-window) main process modules, deprecating & replacing `BrowserView` ([#35658](https://github.com/electron/electron/pull/35658))
   - `BrowserView` is now a shim over `WebContentsView` and the old implementation has been removed.
   - See [our Web Embeds documentation](https://www.electronjs.org/docs/latest/tutorial/web-embeds) for a comparison of the new `WebContentsView` API to other similar APIs.
-- Added [`net`](https://www.electronjs.org/docs/latest/api/net) module to utility process ([#40017](https://github.com/electron/electron/pull/40017))
 - Implemented support for the [File System API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API) ([#41827](https://github.com/electron/electron/commit/cf1087badd437906f280373decb923733a8523e6))
 
 ### Stack Changes
@@ -42,6 +41,15 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 - V8 `12.4`
 
 Electron 30 upgrades Chromium from `122.0.6261.39` to `124.0.6367.49`, Node from `20.9.0` to `20.11.1`, and V8 from `12.2` to `12.4`.
+
+### New Features
+
+- Added a `transparent` webpreference to webviews. ([#40301](https://github.com/electron/electron/pull/40301))
+- Added a new instance property `navigationHistory` on webContents API with `navigationHistory.getEntryAtIndex` method, enabling applications to retrieve the URL and title of any navigation entry within the browsing history. ([#41662](https://github.com/electron/electron/pull/41662)) <span style="font-size:small;">(Also in [29](https://github.com/electron/electron/pull/41661))</span>
+- Added a new method `BrowserWindow.isOccluded()` to allow apps to check occlusion status. ([#38982](https://github.com/electron/electron/pull/38982))
+- Added proxy configuring support for requests made with net module from utility process. ([#41417](https://github.com/electron/electron/pull/41417)) <span style="font-size:small;">(Also in [28](https://github.com/electron/electron/pull/41744), [29](https://github.com/electron/electron/pull/41416))</span>
+- Added support for Bluetooth ports being requested by service class ID in `navigator.serial`. ([#41734](https://github.com/electron/electron/pull/41734)) <span style="font-size:small;">(Also in [29](https://github.com/electron/electron/pull/41735))</span>
+- Added support for `NODE_EXTRA_CA_CERTS`. ([#41822](https://github.com/electron/electron/pull/41822))
 
 ### Breaking Changes
 

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -23,12 +23,12 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 
 ### Highlights
 
-* ASAR Integrity fuse now supported on Windows [#40504](https://github.com/electron/electron/pull/40504)
-  * Existing apps with ASAR Integrity enabled may not work on Windows if not configured correctly.
-  * Take a look at our [ASAR Integrity tutorial](https://www.electronjs.org/docs/latest/tutorial/asar-integrity) for more information.
-* Added `WebContentsView` and `BaseWindow`, deprecating & replacing `BrowserView` [#35658](https://github.com/electron/electron/pull/35658)
-* Added `net` module to utility process [#40017](https://github.com/electron/electron/pull/40017)
-* Implemented support for the File System API [#41827](https://github.com/electron/electron/commit/cf1087badd437906f280373decb923733a8523e6)
+- ASAR Integrity fuse now supported on Windows [#40504](https://github.com/electron/electron/pull/40504)
+  - Existing apps with ASAR Integrity enabled may not work on Windows if not configured correctly.
+  - Take a look at our [ASAR Integrity tutorial](https://www.electronjs.org/docs/latest/tutorial/asar-integrity) for more information.
+- Added `WebContentsView` and `BaseWindow`, deprecating & replacing `BrowserView` [#35658](https://github.com/electron/electron/pull/35658)
+- Added `net` module to utility process [#40017](https://github.com/electron/electron/pull/40017)
+- Implemented support for the File System API [#41827](https://github.com/electron/electron/commit/cf1087badd437906f280373decb923733a8523e6)
 
 ### Stack Changes
 

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -57,7 +57,7 @@ This switch was never formally documented but it's removal is being noted here r
 
 #### Behavior Changed: `BrowserView.setAutoResize` behavior on macOS
 
-In Electron 30, BrowserView is now a wrapper around the new [WebContentsView](api/web-contents-view.md) API.
+In Electron 30, BrowserView is now a wrapper around the new [WebContentsView](https://www.electronjs.org/docs/latest/api/web-contents-view) API.
 
 Previously, the `setAutoResize` function of the `BrowserView` API was backed by [autoresizing](https://developer.apple.com/documentation/appkit/nsview/1483281-autoresizingmask?language=objc) on macOS, and by a custom algorithm on Windows and Linux.
 For simple use cases such as making a BrowserView fill the entire window, the behavior of these two approaches was identical.

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -28,7 +28,7 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
   - Take a look at our [ASAR Integrity tutorial](https://www.electronjs.org/docs/latest/tutorial/asar-integrity) for more information.
 - Added `WebContentsView` and `BaseWindow`, deprecating & replacing `BrowserView` ([#35658](https://github.com/electron/electron/pull/35658))
   - See [our Web Embeds documentation](https://www.electronjs.org/docs/latest/tutorial/web-embeds) for a comparison of the new `WebContentsView` API to other similar APIs.
-- Added `net` module to utility process ([#40017](https://github.com/electron/electron/pull/40017))
+- Added [`net`](https://www.electronjs.org/docs/latest/api/net) module to utility process ([#40017](https://github.com/electron/electron/pull/40017))
 - Implemented support for the [File System API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API) ([#41827](https://github.com/electron/electron/commit/cf1087badd437906f280373decb923733a8523e6))
 
 ### Stack Changes

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -5,6 +5,9 @@ authors:
   - name: clavin
     url: 'https://github.com/clavin'
     image_url: 'https://github.com/clavin.png?size=96'
+  - name: VerteDinde
+    url: 'https://github.com/vertedinde'
+    image_url: 'https://github.com/vertedinde.png?size=96'
 slug: electron-30-0
 ---
 

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -11,7 +11,7 @@ authors:
 slug: electron-30-0
 ---
 
-Electron 30.0.0 has been released! It includes upgrades to Chromium `124.0.6367.29`, V8 `12.5`, and Node.js `20.11.1`.
+Electron 30.0.0 has been released! It includes upgrades to Chromium `124.0.6367.49`, V8 `12.4`, and Node.js `20.11.1`.
 
 ---
 

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -46,10 +46,10 @@ Electron 30 upgrades Chromium from `122.0.6261.39` to `124.0.6367.49`, Node from
 
 - Added a `transparent` webpreference to webviews. ([#40301](https://github.com/electron/electron/pull/40301))
 - Added a new instance property `navigationHistory` on webContents API with `navigationHistory.getEntryAtIndex` method, enabling applications to retrieve the URL and title of any navigation entry within the browsing history. ([#41662](https://github.com/electron/electron/pull/41662)) <span style="font-size:small;">(Also in [29](https://github.com/electron/electron/pull/41661))</span>
-- Added a new method `BrowserWindow.isOccluded()` to allow apps to check occlusion status. ([#38982](https://github.com/electron/electron/pull/38982))
-- Added proxy configuring support for requests made with net module from utility process. ([#41417](https://github.com/electron/electron/pull/41417)) <span style="font-size:small;">(Also in [28](https://github.com/electron/electron/pull/41744), [29](https://github.com/electron/electron/pull/41416))</span>
+- Added new `BrowserWindow.isOccluded()` method to allow apps to check occlusion status. ([#38982](https://github.com/electron/electron/pull/38982))
+- Added proxy configuring support for requests made with the `net` module from the utility process. ([#41417](https://github.com/electron/electron/pull/41417)) <span style="font-size:small;">(Also in [28](https://github.com/electron/electron/pull/41744), [29](https://github.com/electron/electron/pull/41416))</span>
 - Added support for Bluetooth ports being requested by service class ID in `navigator.serial`. ([#41734](https://github.com/electron/electron/pull/41734)) <span style="font-size:small;">(Also in [29](https://github.com/electron/electron/pull/41735))</span>
-- Added support for `NODE_EXTRA_CA_CERTS`. ([#41822](https://github.com/electron/electron/pull/41822))
+- Added support for the Node.js [`NODE_EXTRA_CA_CERTS`](https://nodejs.org/api/cli.html#node_extra_ca_certsfile) CLI flag. ([#41822](https://github.com/electron/electron/pull/41822))
 
 ### Breaking Changes
 

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -1,0 +1,93 @@
+---
+title: Electron 30.0.0
+date: 2024-04-16T00:00:00.000Z
+authors:
+  - name: clavin
+    url: 'https://github.com/clavin'
+    image_url: 'https://github.com/clavin.png?size=96'
+slug: electron-30-0
+---
+
+Electron 30.0.0 has been released! It includes upgrades to Chromium `124.0.6367.29`, V8 `12.5`, and Node.js `20.11.1`.
+
+---
+
+The Electron team is excited to announce the release of Electron 30.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://releases.electronjs.org/releases/stable). Continue reading for details about this release.
+
+If you have any feedback, please share it with us on [Twitter](https://twitter.com/electronjs) or [Mastodon](https://social.lfx.dev/@electronjs), or join our community [Discord](https://discord.com/invite/electronjs)! Bugs and feature requests can be reported in Electron's [issue tracker](https://github.com/electron/electron/issues).
+
+## Notable Changes
+
+### Highlights
+
+* ASAR Integrity fuse now supported on Windows
+  * Existing apps with ASAR Integrity enabled may not work on Windows if not configured correctly.
+  * Take a look at our [ASAR Integrity tutorial](https://www.electronjs.org/docs/latest/tutorial/asar-integrity) for more information.
+* Added `WebContentsView` and `BaseWindow`, deprecating & replacing `BrowserView`
+* Added `net` module to utility process
+* Implemented support for the File System API
+
+### Stack Changes
+
+- Chromium `124.0.6367.49`
+  - New in [Chrome 124](https://developer.chrome.com/blog/new-in-chrome-124/) and in [DevTools 124](https://developer.chrome.com/blog/new-in-devtools-124/)
+  - New in [Chrome 123](https://developer.chrome.com/blog/new-in-chrome-123/) and in [DevTools 123](https://developer.chrome.com/blog/new-in-devtools-123/)
+- Node `20.11.1`
+  - [Node 20.11.1 notes](https://nodejs.org/en/blog/release/v20.11.1/)
+- V8 `12.4`
+
+Electron 29 upgrades Chromium from `122.0.6261.39` to `124.0.6367.49`, Node from `20.9.0` to `20.11.1`, and V8 from `12.2` to `12.4`.
+
+### Breaking Changes
+
+#### Behavior Changed: cross-origin iframes now use Permission Policy to access features
+
+Cross-origin iframes must now specify features available to a given `iframe` via the `allow`
+attribute in order to access them.
+
+See [documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#allow) for
+more information.
+
+#### Removed: The `--disable-color-correct-rendering` switch
+
+This switch was never formally documented but it's removal is being noted here regardless. Chromium itself now has better support for color spaces so this flag should not be needed.
+
+#### Behavior Changed: `BrowserView.setAutoResize` behavior on macOS
+
+In Electron 30, BrowserView is now a wrapper around the new [WebContentsView](api/web-contents-view.md) API.
+
+Previously, the `setAutoResize` function of the `BrowserView` API was backed by [autoresizing](https://developer.apple.com/documentation/appkit/nsview/1483281-autoresizingmask?language=objc) on macOS, and by a custom algorithm on Windows and Linux.
+For simple use cases such as making a BrowserView fill the entire window, the behavior of these two approaches was identical.
+However, in more advanced cases, BrowserViews would be autoresized differently on macOS than they would be on other platforms, as the custom resizing algorithm for Windows and Linux did not perfectly match the behavior of macOS's autoresizing API.
+The autoresizing behavior is now standardized across all platforms.
+
+If your app uses `BrowserView.setAutoResize` to do anything more complex than making a BrowserView fill the entire window, it's likely you already had custom logic in place to handle this difference in behavior on macOS.
+If so, that logic will no longer be needed in Electron 30 as autoresizing behavior is consistent.
+
+#### Removed: `params.inputFormType` property on `context-menu` on `WebContents`
+
+The `inputFormType` property of the params object in the `context-menu`
+event from `WebContents` has been removed. Use the new `formControlType`
+property instead.
+
+#### Removed: `process.getIOCounters()`
+
+Chromium has removed access to this information.
+
+## End of Support for 27.x.y
+
+Electron 27.x.y has reached end-of-support as per the project's [support policy](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#version-support-policy). Developers and applications are encouraged to upgrade to a newer version of Electron.
+
+| E30 (Apr'24) | E31 (Jun'24) | E32 (Aug'24) |
+| ------------ | ------------ | ------------ |
+| 30.x.y       | 31.x.y       | 32.x.y       |
+| 29.x.y       | 30.x.y       | 31.x.y       |
+| 28.x.y       | 29.x.y       | 30.x.y       |
+
+## What's Next
+
+In the short term, you can expect the team to continue to focus on keeping up with the development of the major components that make up Electron, including Chromium, Node, and V8.
+
+You can find [Electron's public timeline here](https://www.electronjs.org/docs/latest/tutorial/electron-timelines).
+
+More information about future changes can be found on the [Planned Breaking Changes](https://github.com/electron/electron/blob/main/docs/breaking-changes.md) page.


### PR DESCRIPTION
This PR adds a new blog post for Electron 30. @electron/wg-releases, @electron/wg-outreach

Merge target: April 16th, after 30.0.0 releases.

⚠️ Do not merge until the following are completed ⚠️

* [x]   update node, v8 and chromium versions from final chrome roll under Stack Changes section
* [x]   edit link for M124 "New In Chrome" blog post
* [x]   add a few bullets for New Features section
* [x]   add any missing items in Breaking Changes section
* [x]   update End of Support

_Note: The "Check Blog links" job is going to fail until the Chrome 122 announcement blog comes out, a fail there is expected until about Tuesday_

