### PR TITLE
ci: bump tj-actions/changed-files version

### DIFF
--- a/.github/workflows/check-blog-links.yml
+++ b/.github/workflows/check-blog-links.yml
@@ -23,7 +23,7 @@ jobs:
         run: yarn install
       - name: Check for changed blog posts
         id: check-for-changed-blog-posts
-        uses: tj-actions/changed-files@2d756ea4c53f7f6b397767d8723b3a10a9f35bf2 # v44.0.0
+        uses: tj-actions/changed-files@0874344d6ebbaa00a27da73276ae7162fadcaf69 # v44.3.0
         with:
           files: blog/*.md
       - name: Check blog post links


### PR DESCRIPTION
Dependabot is convinced this is using an old version (<41) which has a security vulnerability, even though we're using v44. I'm hoping bumping it here will clear the erroneous security alert.