### PR TITLE
fix(build): use `tsx` for build scripts

### DIFF
--- a/docs/latest/api/app.md
+++ b/docs/latest/api/app.md
@@ -39,7 +39,7 @@ In most cases, you should do everything in the `ready` event handler.
 Returns:
 
 * `event` Event
-* `launchInfo` Record&#60;string, any\&#62; | [NotificationResponse](latest/api/structures/notification-response.md) _macOS_
+* `launchInfo` Record\<string, any\> | [NotificationResponse](latest/api/structures/notification-response.md) _macOS_
 
 Emitted once, when Electron has finished initializing. On macOS, `launchInfo`
 holds the `userInfo` of the [`NSUserNotification`](https://developer.apple.com/documentation/foundation/nsusernotification)
@@ -848,7 +848,7 @@ This method returns the application name of the default handler for the protocol
 Returns `Promise<Object>` - Resolve with an object containing the following:
 
 * `icon` NativeImage - the display icon of the app handling the protocol.
-* `path` string - installation path of the app handling the protocol.
+* `path` string  - installation path of the app handling the protocol.
 * `name` string - display name of the app handling the protocol.
 
 This method returns a promise that contains the application name, icon and path of the default handler for the protocol
@@ -981,7 +981,7 @@ app.setJumpList([
 
 ### `app.requestSingleInstanceLock([additionalData])`
 
-* `additionalData` Record&#60;any, any\&#62; (optional) - A JSON object containing additional data to send to the first instance.
+* `additionalData` Record\<any, any\> (optional) - A JSON object containing additional data to send to the first instance.
 
 Returns `boolean`
 
@@ -1420,7 +1420,7 @@ systems Application folder. Use in combination with `app.moveToApplicationsFolde
 ### `app.moveToApplicationsFolder([options])` _macOS_
 
 * `options` Object (optional)
-  * `conflictHandler` Function&#60;boolean&#62; (optional) - A handler for potential conflict in move failure.
+  * `conflictHandler` Function\<boolean> (optional) - A handler for potential conflict in move failure.
     * `conflictType` string - The type of move conflict encountered by the handler; can be `exists` or `existsAndRunning`, where `exists` means that an app of the same name is present in the Applications directory and `existsAndRunning` means both that it exists and that it's presently running.
 
 Returns `boolean` - Whether the move was successful. Please note that if

--- a/docs/latest/api/auto-updater.md
+++ b/docs/latest/api/auto-updater.md
@@ -111,7 +111,7 @@ The `autoUpdater` object has the following methods:
 
 * `options` Object
   * `url` string
-  * `headers` Record&#60;string, string\&#62; (optional) _macOS_ - HTTP request headers.
+  * `headers` Record\<string, string\> (optional) _macOS_ - HTTP request headers.
   * `serverType` string (optional) _macOS_ - Can be `json` or `default`, see the [Squirrel.Mac][squirrel-mac]
     README for more information.
 

--- a/docs/latest/api/base-window.md
+++ b/docs/latest/api/base-window.md
@@ -813,7 +813,7 @@ Closes the currently open [Quick Look][quick-look] panel.
 
 #### `win.setBounds(bounds[, animate])`
 
-* `bounds` Partial&#60;[Rectangle](latest/api/structures/rectangle.md)\&#62;
+* `bounds` Partial\<[Rectangle](latest/api/structures/rectangle.md)\>
 * `animate` boolean (optional) _macOS_
 
 Resizes and moves the window to the supplied bounds. Any properties that are not supplied will default to their current values.

--- a/docs/latest/api/browser-window.md
+++ b/docs/latest/api/browser-window.md
@@ -936,7 +936,7 @@ Closes the currently open [Quick Look][quick-look] panel.
 
 #### `win.setBounds(bounds[, animate])`
 
-* `bounds` Partial&#60;[Rectangle](latest/api/structures/rectangle.md)\&#62;
+* `bounds` Partial\<[Rectangle](latest/api/structures/rectangle.md)\>
 * `animate` boolean (optional) _macOS_
 
 Resizes and moves the window to the supplied bounds. Any properties that are not supplied will default to their current values.
@@ -1372,7 +1372,7 @@ win.loadURL('http://localhost:8000/post', {
 
 * `filePath` string
 * `options` Object (optional)
-  * `query` Record&#60;string, string\&#62; (optional) - Passed to `url.format()`.
+  * `query` Record\<string, string\> (optional) - Passed to `url.format()`.
   * `search` string (optional) - Passed to `url.format()`.
   * `hash` string (optional) - Passed to `url.format()`.
 

--- a/docs/latest/api/client-request.md
+++ b/docs/latest/api/client-request.md
@@ -24,7 +24,7 @@ following properties:
     method.
   * `url` string (optional) - The request URL. Must be provided in the absolute
     form with the protocol scheme specified as http or https.
-  * `headers` Record&#60;string, string | string[]\&#62; (optional) - Headers to be sent
+  * `headers` Record\<string, string | string[]\> (optional) - Headers to be sent
     with the request.
   * `session` Session (optional) - The [`Session`](latest/api/session.md) instance with
     which the request is associated.
@@ -167,7 +167,7 @@ Returns:
 * `statusCode` Integer
 * `method` string
 * `redirectUrl` string
-* `responseHeaders` Record&#60;string, string[]\&#62;
+* `responseHeaders` Record\<string, string[]\>
 
 Emitted when the server returns a redirect response (e.g. 301 Moved
 Permanently). Calling [`request.followRedirect`](#requestfollowredirect) will

--- a/docs/latest/api/crash-reporter.md
+++ b/docs/latest/api/crash-reporter.md
@@ -66,14 +66,14 @@ The `crashReporter` module has the following methods:
     number of crashes uploaded to 1/hour. Default is `false`.
   * `compress` boolean (optional) - If true, crash reports will be compressed
     and uploaded with `Content-Encoding: gzip`. Default is `true`.
-  * `extra` Record&#60;string, string\&#62; (optional) - Extra string key/value
+  * `extra` Record\<string, string\> (optional) - Extra string key/value
     annotations that will be sent along with crash reports that are generated
     in the main process. Only string values are supported. Crashes generated in
     child processes will not contain these extra
     parameters to crash reports generated from child processes, call
     [`addExtraParameter`](#crashreporteraddextraparameterkey-value) from the
     child process.
-  * `globalExtra` Record&#60;string, string\&#62; (optional) - Extra string key/value
+  * `globalExtra` Record\<string, string\> (optional) - Extra string key/value
     annotations that will be sent along with any crash reports generated in any
     process. These annotations cannot be changed once the crash reporter has
     been started. If a key is present in both the global extra parameters and

--- a/docs/latest/api/ipc-main.md
+++ b/docs/latest/api/ipc-main.md
@@ -72,7 +72,7 @@ Removes listeners of the specified `channel`.
 ### `ipcMain.handle(channel, listener)`
 
 * `channel` string
-* `listener` Function&#60;Promise&#60;any\&#62; | any\&#62;
+* `listener` Function\<Promise\<any\> | any\>
   * `event` [IpcMainInvokeEvent][ipc-main-invoke-event]
   * `...args` any[]
 
@@ -109,7 +109,7 @@ provided to the renderer process. Please refer to
 ### `ipcMain.handleOnce(channel, listener)`
 
 * `channel` string
-* `listener` Function&#60;Promise&#60;any\&#62; | any\&#62;
+* `listener` Function\<Promise\<any\> | any\>
   * `event` [IpcMainInvokeEvent][ipc-main-invoke-event]
   * `...args` any[]
 

--- a/docs/latest/api/protocol.md
+++ b/docs/latest/api/protocol.md
@@ -121,7 +121,7 @@ expect streaming responses.
 
 * `scheme` string - scheme to handle, for example `https` or `my-app`. This is
   the bit before the `:` in a URL.
-* `handler` Function&#60;[GlobalResponse](https://nodejs.org/api/globals.html#response) | Promise&#60;GlobalResponse\&#62;\&#62;
+* `handler` Function\<[GlobalResponse](https://nodejs.org/api/globals.html#response) | Promise\<GlobalResponse\>\>
   * `request` [GlobalRequest](https://nodejs.org/api/globals.html#request)
 
 Register a protocol handler for `scheme`. Requests made to URLs with this

--- a/docs/latest/api/push-notifications.md
+++ b/docs/latest/api/push-notifications.md
@@ -34,7 +34,7 @@ The `pushNotification` module emits the following events:
 Returns:
 
 * `event` Event
-* `userInfo` Record&#60;String, any\&#62;
+* `userInfo` Record\<String, any\>
 
 Emitted when the app receives a remote notification while running.
 See: https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428430-application?language=objc

--- a/docs/latest/api/session.md
+++ b/docs/latest/api/session.md
@@ -848,7 +848,7 @@ session.fromPartition('some-partition').setPermissionRequestHandler((webContents
 
 #### `ses.setPermissionCheckHandler(handler)`
 
-* `handler` Function&#60;boolean&#62; | null
+* `handler` Function\<boolean> | null
   * `webContents` ([WebContents](latest/api/web-contents.md) | null) - WebContents checking the permission.  Please note that if the request comes from a subframe you should use `requestingUrl` to check the request origin.  All cross origin sub frames making permission checks will pass a `null` webContents to this handler, while certain other permission checks such as `notifications` checks will always pass `null`.  You should use `embeddingOrigin` and `requestingOrigin` to determine what origin the owning frame and the requesting frame are on respectively.
   * `permission` string - Type of permission check.
     * `clipboard-read` - Request access to read from the clipboard.
@@ -955,7 +955,7 @@ Passing `null` instead of a function resets the handler to its default state.
 
 #### `ses.setDevicePermissionHandler(handler)`
 
-* `handler` Function&#60;boolean&#62; | null
+* `handler` Function\<boolean> | null
   * `details` Object
     * `deviceType` string - The type of device that permission is being requested on, can be `hid`, `serial`, or `usb`.
     * `origin` string - The origin URL of the device permission check.
@@ -1028,7 +1028,7 @@ app.whenReady().then(() => {
 
 #### `ses.setUSBProtectedClassesHandler(handler)`
 
-* `handler` Function&#60;string[]&#62; | null
+* `handler` Function\<string[]> | null
   * `details` Object
     * `protectedClasses` string[] - The current list of protected USB classes. Possible class values include:
       * `audio`
@@ -1221,7 +1221,7 @@ Returns `Promise<Buffer>` - resolves with blob data.
 
 * `url` string
 * `options` Object (optional)
-  * `headers` Record&#60;string, string\&#62; (optional) - HTTP request headers.
+  * `headers` Record\<string, string\> (optional) - HTTP request headers.
 
 Initiates a download of the resource at `url`.
 The API will generate a [DownloadItem](latest/api/download-item.md) that can be accessed

--- a/docs/latest/api/structures/file-path-with-headers.md
+++ b/docs/latest/api/structures/file-path-with-headers.md
@@ -8,4 +8,4 @@ hide_title: false
 # FilePathWithHeaders Object
 
 * `path` string - The path to the file to send.
-* `headers` Record&#60;string, string\&#62; (optional) - Additional headers to be sent.
+* `headers` Record\<string, string\> (optional) - Additional headers to be sent.

--- a/docs/latest/api/structures/notification-response.md
+++ b/docs/latest/api/structures/notification-response.md
@@ -10,5 +10,5 @@ hide_title: false
 * `actionIdentifier` string - The identifier string of the action that the user selected.
 * `date` number - The delivery date of the notification.
 * `identifier` string - The unique identifier for this notification request.
-* `userInfo` Record&#60;string, any\&#62; - A dictionary of custom information associated with the notification.
+* `userInfo` Record\<string, any\> - A dictionary of custom information associated with the notification.
 * `userText` string (optional) - The text entered or chosen by the user.

--- a/docs/latest/api/structures/protocol-request.md
+++ b/docs/latest/api/structures/protocol-request.md
@@ -11,4 +11,4 @@ hide_title: false
 * `referrer` string
 * `method` string
 * `uploadData` [UploadData[]](latest/api/structures/upload-data.md) (optional)
-* `headers` Record&#60;string, string\&#62;
+* `headers` Record\<string, string\>

--- a/docs/latest/api/structures/protocol-response.md
+++ b/docs/latest/api/structures/protocol-response.md
@@ -17,7 +17,7 @@ hide_title: false
   `"text/html"`. Setting `mimeType` would implicitly set the `content-type`
   header in response, but if `content-type` is already set in `headers`, the
   `mimeType` would be ignored.
-* `headers` Record&#60;string, string | string[]\&#62; (optional) - An object containing the response headers. The
+* `headers` Record\<string, string | string[]\> (optional) - An object containing the response headers. The
   keys must be string, and values must be either string or Array of string.
 * `data` (Buffer | string | ReadableStream) (optional) - The response body. When
   returning stream as response, this is a Node.js readable stream representing

--- a/docs/latest/api/structures/transaction.md
+++ b/docs/latest/api/structures/transaction.md
@@ -15,6 +15,6 @@ hide_title: false
 * `errorMessage` string - The error message if an error occurred while processing the transaction.
 * `payment` Object
   * `productIdentifier` string - The identifier of the purchased product.
-  * `quantity` Integer - The quantity purchased.
+  * `quantity` Integer  - The quantity purchased.
   * `applicationUsername` string - An opaque identifier for the user’s account on your system.
   * `paymentDiscount` [PaymentDiscount](latest/api/structures/payment-discount.md) (optional) - The details of the discount offer to apply to the payment.

--- a/docs/latest/api/structures/user-default-types.md
+++ b/docs/latest/api/structures/user-default-types.md
@@ -13,7 +13,7 @@ hide_title: false
 * `float` number
 * `double` number
 * `url` string
-* `array` Array&#60;unknown&#62;
-* `dictionary` Record&#60;string, unknown&#62;
+* `array` Array\<unknown>
+* `dictionary` Record\<string, unknown>
 
 This type is a helper alias, no object will ever exist of this type.

--- a/docs/latest/api/system-preferences.md
+++ b/docs/latest/api/system-preferences.md
@@ -43,7 +43,7 @@ Returns `boolean` - Whether the Swipe between pages setting is on.
 ### `systemPreferences.postNotification(event, userInfo[, deliverImmediately])` _macOS_
 
 * `event` string
-* `userInfo` Record&#60;string, any\&#62;
+* `userInfo` Record\<string, any\>
 * `deliverImmediately` boolean (optional) - `true` to post notifications immediately even when the subscribing app is inactive.
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
@@ -52,7 +52,7 @@ that contains the user information dictionary sent along with the notification.
 ### `systemPreferences.postLocalNotification(event, userInfo)` _macOS_
 
 * `event` string
-* `userInfo` Record&#60;string, any\&#62;
+* `userInfo` Record\<string, any\>
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
 that contains the user information dictionary sent along with the notification.
@@ -60,7 +60,7 @@ that contains the user information dictionary sent along with the notification.
 ### `systemPreferences.postWorkspaceNotification(event, userInfo)` _macOS_
 
 * `event` string
-* `userInfo` Record&#60;string, any\&#62;
+* `userInfo` Record\<string, any\>
 
 Posts `event` as native notifications of macOS. The `userInfo` is an Object
 that contains the user information dictionary sent along with the notification.
@@ -70,7 +70,7 @@ that contains the user information dictionary sent along with the notification.
 * `event` string | null
 * `callback` Function
   * `event` string
-  * `userInfo` Record&#60;string, unknown\&#62;
+  * `userInfo` Record\<string, unknown\>
   * `object` string
 
 Returns `number` - The ID of this subscription
@@ -99,7 +99,7 @@ If `event` is null, the `NSDistributedNotificationCenter` doesn’t use it as cr
 * `event` string | null
 * `callback` Function
   * `event` string
-  * `userInfo` Record&#60;string, unknown\&#62;
+  * `userInfo` Record\<string, unknown\>
   * `object` string
 
 Returns `number` - The ID of this subscription
@@ -114,7 +114,7 @@ If `event` is null, the `NSNotificationCenter` doesn’t use it as criteria for 
 * `event` string | null
 * `callback` Function
   * `event` string
-  * `userInfo` Record&#60;string, unknown\&#62;
+  * `userInfo` Record\<string, unknown\>
   * `object` string
 
 Returns `number` - The ID of this subscription
@@ -144,7 +144,7 @@ Same as `unsubscribeNotification`, but removes the subscriber from `NSWorkspace.
 
 ### `systemPreferences.registerDefaults(defaults)` _macOS_
 
-* `defaults` Record&#60;string, string | boolean | number\&#62; - a dictionary of (`key: value`) user defaults
+* `defaults` Record\<string, string | boolean | number\> - a dictionary of (`key: value`) user defaults
 
 Add the specified defaults to your application's `NSUserDefaults`.
 

--- a/docs/latest/api/web-contents.md
+++ b/docs/latest/api/web-contents.md
@@ -244,7 +244,7 @@ See [`window.open()`](latest/api/window-open.md) for more details and how to use
 
 Returns:
 
-* `details` Event&#60;\&#62;
+* `details` Event\<\>
   * `url` string - The URL the frame is navigating to.
   * `isSameDocument` boolean - This event does not fire for same document navigations using window.history api and reference fragment navigations.
     This property is always set to `false` for this event.
@@ -277,7 +277,7 @@ Calling `event.preventDefault()` will prevent the navigation.
 
 Returns:
 
-* `details` Event&#60;\&#62;
+* `details` Event\<\>
   * `url` string - The URL the frame is navigating to.
   * `isSameDocument` boolean - This event does not fire for same document navigations using window.history api and reference fragment navigations.
     This property is always set to `false` for this event.
@@ -307,7 +307,7 @@ Calling `event.preventDefault()` will prevent the navigation.
 
 Returns:
 
-* `details` Event&#60;\&#62;
+* `details` Event\<\>
   * `url` string - The URL the frame is navigating to.
   * `isSameDocument` boolean - Whether the navigation happened without changing
     document. Examples of same document navigations are reference fragment
@@ -331,7 +331,7 @@ Emitted when any frame (including main) starts navigating.
 
 Returns:
 
-* `details` Event&#60;\&#62;
+* `details` Event\<\>
   * `url` string - The URL the frame is navigating to.
   * `isSameDocument` boolean - Whether the navigation happened without changing
     document. Examples of same document navigations are reference fragment
@@ -362,7 +362,7 @@ redirect).
 
 Returns:
 
-* `details` Event&#60;\&#62;
+* `details` Event\<\>
   * `url` string - The URL the frame is navigating to.
   * `isSameDocument` boolean - Whether the navigation happened without changing
     document. Examples of same document navigations are reference fragment
@@ -688,7 +688,7 @@ Emitted when media is paused or done playing.
 
 Returns:
 
-* `event` Event&#60;\&#62;
+* `event` Event\<\>
   * `audible` boolean - True if one or more frames or child `webContents` are emitting audio.
 
 Emitted when media becomes audible or inaudible.
@@ -905,7 +905,7 @@ Returns:
 * `webPreferences` [WebPreferences](latest/api/structures/web-preferences.md) - The web preferences that will be used by the guest
   page. This object can be modified to adjust the preferences for the guest
   page.
-* `params` Record&#60;string, string\&#62; - The other `<webview>` parameters such as the `src` URL.
+* `params` Record\<string, string\> - The other `<webview>` parameters such as the `src` URL.
   This object can be modified to adjust the parameters of the guest page.
 
 Emitted when a `<webview>`'s web contents is being attached to this web
@@ -1025,7 +1025,7 @@ win.webContents.loadURL('https://github.com', options)
 
 * `filePath` string
 * `options` Object (optional)
-  * `query` Record&#60;string, string\&#62; (optional) - Passed to `url.format()`.
+  * `query` Record\<string, string\> (optional) - Passed to `url.format()`.
   * `search` string (optional) - Passed to `url.format()`.
   * `hash` string (optional) - Passed to `url.format()`.
 
@@ -1056,7 +1056,7 @@ win.loadFile('src/index.html')
 
 * `url` string
 * `options` Object (optional)
-  * `headers` Record&#60;string, string\&#62; (optional) - HTTP request headers.
+  * `headers` Record\<string, string\> (optional) - HTTP request headers.
 
 Initiates a download of the resource at `url` without navigating. The
 `will-download` event of `session` will be triggered.
@@ -1293,7 +1293,7 @@ Ignore application menu shortcuts while this web contents is focused.
 
 #### `contents.setWindowOpenHandler(handler)`
 
-* `handler` Function&#60;\{action: 'deny'\} | \{action: 'allow', outlivesOpener?: boolean, overrideBrowserWindowOptions?: BrowserWindowConstructorOptions\}\&#62;
+* `handler` Function\<\{action: 'deny'\} | \{action: 'allow', outlivesOpener?: boolean, overrideBrowserWindowOptions?: BrowserWindowConstructorOptions\}\>
   * `details` Object
     * `url` string - The _resolved_ version of the URL passed to `window.open()`. e.g. opening a window with `window.open('foo')` will yield something like `https://the-origin/the/current/path/foo`.
     * `frameName` string - Name of the window provided in `window.open()`
@@ -1571,7 +1571,7 @@ Returns `Promise<PrinterInfo[]>` - Resolves with a [`PrinterInfo[]`](latest/api/
     * `from` number - Index of the first page to print (0-based).
     * `to` number - Index of the last page to print (inclusive) (0-based).
   * `duplexMode` string (optional) - Set the duplex mode of the printed web page. Can be `simplex`, `shortEdge`, or `longEdge`.
-  * `dpi` Record&#60;string, number\&#62; (optional)
+  * `dpi` Record\<string, number\> (optional)
     * `horizontal` number (optional) - The horizontal dpi.
     * `vertical` number (optional) - The vertical dpi.
   * `header` string (optional) - string to be printed as page header.
@@ -1612,7 +1612,7 @@ win.webContents.print(options, (success, errorType) => {
   * `landscape` boolean (optional) - Paper orientation.`true` for landscape, `false` for portrait. Defaults to false.
   * `displayHeaderFooter` boolean (optional) - Whether to display header and footer. Defaults to false.
   * `printBackground` boolean (optional) - Whether to print background graphics. Defaults to false.
-  * `scale` number(optional) - Scale of the webpage rendering. Defaults to 1.
+  * `scale` number(optional)  - Scale of the webpage rendering. Defaults to 1.
   * `pageSize` string | Size (optional) - Specify page size of the generated PDF. Can be `A0`, `A1`, `A2`, `A3`,
   `A4`, `A5`, `A6`, `Legal`, `Letter`, `Tabloid`, `Ledger`, or an Object containing `height` and `width` in inches. Defaults to `Letter`.
   * `margins` Object (optional)

--- a/docs/latest/api/web-request.md
+++ b/docs/latest/api/web-request.md
@@ -106,11 +106,11 @@ Some examples of valid `urls`:
     * `referrer` string
     * `timestamp` Double
     * `uploadData` [UploadData[]](latest/api/structures/upload-data.md) (optional)
-    * `requestHeaders` Record&#60;string, string\&#62;
+    * `requestHeaders` Record\<string, string\>
   * `callback` Function
     * `beforeSendResponse` Object
       * `cancel` boolean (optional)
-      * `requestHeaders` Record&#60;string, string | string[]\&#62; (optional) - When provided, request will be made
+      * `requestHeaders` Record\<string, string | string[]\> (optional) - When provided, request will be made
   with these headers.
 
 The `listener` will be called with `listener(details, callback)` before sending
@@ -133,7 +133,7 @@ The `callback` has to be called with a `response` object.
     * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
     * `referrer` string
     * `timestamp` Double
-    * `requestHeaders` Record&#60;string, string\&#62;
+    * `requestHeaders` Record\<string, string\>
 
 The `listener` will be called with `listener(details)` just before a request is
 going to be sent to the server, modifications of previous `onBeforeSendHeaders`
@@ -155,11 +155,11 @@ response are visible by the time this listener is fired.
     * `timestamp` Double
     * `statusLine` string
     * `statusCode` Integer
-    * `responseHeaders` Record&#60;string, string[]\&#62; (optional)
+    * `responseHeaders` Record\<string, string[]\> (optional)
   * `callback` Function
     * `headersReceivedResponse` Object
       * `cancel` boolean (optional)
-      * `responseHeaders` Record&#60;string, string | string[]\&#62; (optional) - When provided, the server is assumed
+      * `responseHeaders` Record\<string, string | string[]\> (optional) - When provided, the server is assumed
         to have responded with these headers.
       * `statusLine` string (optional) - Should be provided when overriding
         `responseHeaders` to change header status otherwise original response
@@ -184,7 +184,7 @@ The `callback` has to be called with a `response` object.
     * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
     * `referrer` string
     * `timestamp` Double
-    * `responseHeaders` Record&#60;string, string[]\&#62; (optional)
+    * `responseHeaders` Record\<string, string[]\> (optional)
     * `fromCache` boolean - Indicates whether the response was fetched from disk
       cache.
     * `statusCode` Integer
@@ -214,7 +214,7 @@ and response headers are available.
     * `ip` string (optional) - The server IP address that the request was
       actually sent to.
     * `fromCache` boolean
-    * `responseHeaders` Record&#60;string, string[]\&#62; (optional)
+    * `responseHeaders` Record\<string, string[]\> (optional)
 
 The `listener` will be called with `listener(details)` when a server initiated
 redirect is about to occur.
@@ -233,7 +233,7 @@ redirect is about to occur.
     * `resourceType` string - Can be `mainFrame`, `subFrame`, `stylesheet`, `script`, `image`, `font`, `object`, `xhr`, `ping`, `cspReport`, `media`, `webSocket` or `other`.
     * `referrer` string
     * `timestamp` Double
-    * `responseHeaders` Record&#60;string, string[]\&#62; (optional)
+    * `responseHeaders` Record\<string, string[]\> (optional)
     * `fromCache` boolean
     * `statusCode` Integer
     * `statusLine` string

--- a/docs/latest/api/webview-tag.md
+++ b/docs/latest/api/webview-tag.md
@@ -292,7 +292,7 @@ e.g. the `http://` or `file://`.
 
 * `url` string
 * `options` Object (optional)
-  * `headers` Record&#60;string, string\&#62; (optional) - HTTP request headers.
+  * `headers` Record\<string, string\> (optional) - HTTP request headers.
 
 Initiates a download of the resource at `url` without navigating.
 
@@ -585,7 +585,7 @@ Stops any `findInPage` request for the `webview` with the provided `action`.
     * `from` number - Index of the first page to print (0-based).
     * `to` number - Index of the last page to print (inclusive) (0-based).
   * `duplexMode` string (optional) - Set the duplex mode of the printed web page. Can be `simplex`, `shortEdge`, or `longEdge`.
-  * `dpi` Record&#60;string, number\&#62; (optional)
+  * `dpi` Record\<string, number\> (optional)
     * `horizontal` number (optional) - The horizontal dpi.
     * `vertical` number (optional) - The vertical dpi.
   * `header` string (optional) - string to be printed as page header.
@@ -603,7 +603,7 @@ Prints `webview`'s web page. Same as `webContents.print([options])`.
   * `landscape` boolean (optional) - Paper orientation.`true` for landscape, `false` for portrait. Defaults to false.
   * `displayHeaderFooter` boolean (optional) - Whether to display header and footer. Defaults to false.
   * `printBackground` boolean (optional) - Whether to print background graphics. Defaults to false.
-  * `scale` number(optional) - Scale of the webpage rendering. Defaults to 1.
+  * `scale` number(optional)  - Scale of the webpage rendering. Defaults to 1.
   * `pageSize` string | Size (optional) - Specify page size of the generated PDF. Can be `A0`, `A1`, `A2`, `A3`,
   `A4`, `A5`, `A6`, `Legal`, `Letter`, `Tabloid`, `Ledger`, or an Object containing `height` and `width` in inches. Defaults to `Letter`.
   * `margins` Object (optional)
@@ -661,7 +661,7 @@ examples.
 
 ### `<webview>.sendInputEvent(event)`
 
-* `event` [MouseInputEvent](latest/api/structures/mouse-input-event.md) | [MouseWheelInputEvent](latest/api/structures/mouse-wheel-input-event.md) | [KeyboardInputEvent](latest/api/structures/keyboard-input-event.md)
+* `event`  [MouseInputEvent](latest/api/structures/mouse-input-event.md) | [MouseWheelInputEvent](latest/api/structures/mouse-wheel-input-event.md) | [KeyboardInputEvent](latest/api/structures/keyboard-input-event.md)
 
 Returns `Promise<void>`
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "update-l10n-sources": "npx tsx scripts/update-l10n-sources.ts",
     "lint:eslint": "eslint \"src/**/*.{js,jsx,ts,tsx}\" \"scripts/**/*.{js,ts}\"",
     "lint:markdown": "electron-markdownlint \"**/*.md\"",
-    "lint": "prettier . --check && npm run lint:eslint && npm run lint:markdown",
+    "lint": "npx tsc --noEmit && prettier . --check && npm run lint:eslint && npm run lint:markdown",
     "lint:fix": "prettier . --write && npm run lint:eslint --fix && npm run lint:markdown --fix",
     "pre-build": "npx tsx ./scripts/pre-build.ts",
     "prepare": "husky install"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "crowdin": "crowdin",
     "i18n:upload": "crowdin upload sources",
-    "i18n:download": "crowdin download --verbose && ts-node scripts/prepare-i18n-content.ts",
-    "i18n:glossary": "ts-node scripts/update-crowdin-glossary.ts",
+    "i18n:download": "crowdin download --verbose && npx tsx scripts/prepare-i18n-content.ts",
+    "i18n:glossary": "npx tsx scripts/update-crowdin-glossary.ts",
     "i18n:build": "docusaurus build",
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
@@ -21,12 +21,12 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "update-l10n-sources": "ts-node scripts/update-l10n-sources.ts",
+    "update-l10n-sources": "npx tsx scripts/update-l10n-sources.ts",
     "lint:eslint": "eslint \"src/**/*.{js,jsx,ts,tsx}\" \"scripts/**/*.{js,ts}\"",
     "lint:markdown": "electron-markdownlint \"**/*.md\"",
     "lint": "prettier . --check && npm run lint:eslint && npm run lint:markdown",
     "lint:fix": "prettier . --write && npm run lint:eslint --fix && npm run lint:markdown --fix",
-    "pre-build": "ts-node ./scripts/pre-build.ts",
+    "pre-build": "npx tsx ./scripts/pre-build.ts",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -91,6 +91,7 @@
     "remark": "^15.0.0",
     "remark-gfm": "^4.0.0",
     "tar-stream": "^2.2.0",
+    "tsx": "^4.11.2",
     "typescript": "5.3.2",
     "unist-util-visit-parents": "^6.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1954,15 +1954,130 @@
     vscode-languageserver-textdocument "^1.0.8"
     vscode-uri "^3.0.7"
 
+"@esbuild/aix-ppc64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz#a70f4ac11c6a1dfc18b8bbb13284155d933b9537"
+  integrity sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==
+
+"@esbuild/android-arm64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz#db1c9202a5bc92ea04c7b6840f1bbe09ebf9e6b9"
+  integrity sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==
+
 "@esbuild/android-arm@0.15.18":
   version "0.15.18"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.15.18.tgz#266d40b8fdcf87962df8af05b76219bc786b4f80"
   integrity sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==
 
+"@esbuild/android-arm@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.20.2.tgz#3b488c49aee9d491c2c8f98a909b785870d6e995"
+  integrity sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==
+
+"@esbuild/android-x64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.20.2.tgz#3b1628029e5576249d2b2d766696e50768449f98"
+  integrity sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==
+
+"@esbuild/darwin-arm64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz#6e8517a045ddd86ae30c6608c8475ebc0c4000bb"
+  integrity sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==
+
+"@esbuild/darwin-x64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz#90ed098e1f9dd8a9381695b207e1cff45540a0d0"
+  integrity sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==
+
+"@esbuild/freebsd-arm64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz#d71502d1ee89a1130327e890364666c760a2a911"
+  integrity sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==
+
+"@esbuild/freebsd-x64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz#aa5ea58d9c1dd9af688b8b6f63ef0d3d60cea53c"
+  integrity sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==
+
+"@esbuild/linux-arm64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz#055b63725df678379b0f6db9d0fa85463755b2e5"
+  integrity sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==
+
+"@esbuild/linux-arm@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz#76b3b98cb1f87936fbc37f073efabad49dcd889c"
+  integrity sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==
+
+"@esbuild/linux-ia32@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz#c0e5e787c285264e5dfc7a79f04b8b4eefdad7fa"
+  integrity sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==
+
 "@esbuild/linux-loong64@0.15.18":
   version "0.15.18"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz#128b76ecb9be48b60cf5cfc1c63a4f00691a3239"
   integrity sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==
+
+"@esbuild/linux-loong64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz#a6184e62bd7cdc63e0c0448b83801001653219c5"
+  integrity sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==
+
+"@esbuild/linux-mips64el@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz#d08e39ce86f45ef8fc88549d29c62b8acf5649aa"
+  integrity sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==
+
+"@esbuild/linux-ppc64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz#8d252f0b7756ffd6d1cbde5ea67ff8fd20437f20"
+  integrity sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==
+
+"@esbuild/linux-riscv64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz#19f6dcdb14409dae607f66ca1181dd4e9db81300"
+  integrity sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==
+
+"@esbuild/linux-s390x@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz#3c830c90f1a5d7dd1473d5595ea4ebb920988685"
+  integrity sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==
+
+"@esbuild/linux-x64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz#86eca35203afc0d9de0694c64ec0ab0a378f6fff"
+  integrity sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==
+
+"@esbuild/netbsd-x64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz#e771c8eb0e0f6e1877ffd4220036b98aed5915e6"
+  integrity sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==
+
+"@esbuild/openbsd-x64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz#9a795ae4b4e37e674f0f4d716f3e226dd7c39baf"
+  integrity sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==
+
+"@esbuild/sunos-x64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz#7df23b61a497b8ac189def6e25a95673caedb03f"
+  integrity sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==
+
+"@esbuild/win32-arm64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz#f1ae5abf9ca052ae11c1bc806fb4c0f519bacf90"
+  integrity sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==
+
+"@esbuild/win32-ia32@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz#241fe62c34d8e8461cd708277813e1d0ba55ce23"
+  integrity sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==
+
+"@esbuild/win32-x64@0.20.2":
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz#9c907b21e30a52db959ba4f80bb01a0cc403d5cc"
+  integrity sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
@@ -5405,6 +5520,35 @@ esbuild@^0.15.6:
     esbuild-windows-64 "0.15.18"
     esbuild-windows-arm64 "0.15.18"
 
+esbuild@~0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.20.2.tgz#9d6b2386561766ee6b5a55196c6d766d28c87ea1"
+  integrity sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.20.2"
+    "@esbuild/android-arm" "0.20.2"
+    "@esbuild/android-arm64" "0.20.2"
+    "@esbuild/android-x64" "0.20.2"
+    "@esbuild/darwin-arm64" "0.20.2"
+    "@esbuild/darwin-x64" "0.20.2"
+    "@esbuild/freebsd-arm64" "0.20.2"
+    "@esbuild/freebsd-x64" "0.20.2"
+    "@esbuild/linux-arm" "0.20.2"
+    "@esbuild/linux-arm64" "0.20.2"
+    "@esbuild/linux-ia32" "0.20.2"
+    "@esbuild/linux-loong64" "0.20.2"
+    "@esbuild/linux-mips64el" "0.20.2"
+    "@esbuild/linux-ppc64" "0.20.2"
+    "@esbuild/linux-riscv64" "0.20.2"
+    "@esbuild/linux-s390x" "0.20.2"
+    "@esbuild/linux-x64" "0.20.2"
+    "@esbuild/netbsd-x64" "0.20.2"
+    "@esbuild/openbsd-x64" "0.20.2"
+    "@esbuild/sunos-x64" "0.20.2"
+    "@esbuild/win32-arm64" "0.20.2"
+    "@esbuild/win32-ia32" "0.20.2"
+    "@esbuild/win32-x64" "0.20.2"
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -6213,6 +6357,11 @@ fsevents@~2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
+fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.1, function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
@@ -6293,6 +6442,13 @@ get-symbol-description@^1.0.0:
   dependencies:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
+
+get-tsconfig@^4.7.5:
+  version "4.7.5"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.7.5.tgz#5e012498579e9a6947511ed0cd403272c7acbbaf"
+  integrity sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==
+  dependencies:
+    resolve-pkg-maps "^1.0.0"
 
 github-slugger@^1.5.0:
   version "1.5.0"
@@ -10562,6 +10718,11 @@ resolve-pathname@^3.0.0:
   resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
   integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
+resolve-pkg-maps@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
+  integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
+
 resolve@^1.1.6:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
@@ -11570,6 +11731,16 @@ tslib@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+tsx@^4.11.2:
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.11.2.tgz#91791db82cbcd3f7515e623cc9ff288f2aa663dc"
+  integrity sha512-V5DL5v1BuItjsQ2FN9+4OjR7n5cr8hSgN+VGmm/fd2/0cgQdBIWHcQ3bFYm/5ZTmyxkTDBUIaRuW2divgfPe0A==
+  dependencies:
+    esbuild "~0.20.2"
+    get-tsconfig "^4.7.5"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 tunnel@0.0.6, tunnel@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
I removed the `ts-node` dependency in #563, but forgot that we have a bunch of scripts that rely on being run with that package. 🤦

Unfortunately, the move to ES Modules for various packages we rely on made it impossible to just revert the config.

I ran into some issues despite running with the `--esm` flag, and there seem to be some upstream issues with `ts-node` and Node 20: https://github.com/TypeStrong/ts-node/issues/1997

I tried [`tsx`](https://www.npmjs.com/package/tsx) as a drop-in replacement and it seems to work like a charm.

Note that this PR seems to have updated a bunch of docs via the `pre-build` script. I don't know why changes didn't pick this up before, but it seems like all these formatting changes the double whitespaces are present upstream. Might be related to the Remark-related package upgrades from the Docusaurus 3 upgrade.