### PR TITLE
feat: add tags to blog posts

### DIFF
--- a/blog/breach-to-barrier.md
+++ b/blog/breach-to-barrier.md
@@ -6,6 +6,7 @@ authors:
     url: 'https://github.com/felixrieseberg'
     image_url: 'https://github.com/felixrieseberg.png?size=96'
 slug: breach-to-barrier
+tags: [security]
 ---
 
 It’s been more than a week since [CVE-2023-4863: Heap buffer overflow in WebP](https://chromereleases.googleblog.com/2023/09/stable-channel-update-for-desktop_11.html) was made public, leading to a flurry of new releases of software rendering `webp` images: macOS, iOS, Chrome, Firefox, and various Linux distributions all received updates. This followed investigations by Citizen Lab, discovering that an iPhone used by a “Washington DC-based civil society organization” was under attack using a zero-click exploit within iMessage.

--- a/blog/chromium-rce-vulnerability.md
+++ b/blog/chromium-rce-vulnerability.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/zeke'
   image_url: 'https://github.com/zeke.png?size=96'
 slug: chromium-rce-vulnerability
+tags: [security]
 ---
 
 A remote code execution vulnerability has been discovered in Google Chromium

--- a/blog/cve-2019-13720.md
+++ b/blog/cve-2019-13720.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/nornagon'
   image_url: 'https://github.com/nornagon.png?size=96'
 slug: cve-2019-13720
+tags: [security]
 ---
 
 A High severity vulnerability has been discovered in Chrome which affects all software based on Chromium, including Electron.

--- a/blog/electron-1-0.md
+++ b/blog/electron-1-0.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/jlord'
   image_url: 'https://github.com/jlord.png?size=96'
 slug: electron-1-0
+tags: [release]
 ---
 
 For the last two years, Electron has helped developers build cross platform

--- a/blog/electron-10-0.md
+++ b/blog/electron-10-0.md
@@ -9,6 +9,7 @@ authors:
     url: 'https://github.com/sofianguy'
     image_url: 'https://github.com/sofianguy.png?size=96'
 slug: electron-10-0
+tags: [release]
 ---
 
 Electron 10.0.0 has been released! It includes upgrades to Chromium `85`, V8 `8.5`, and Node.js `12.16`. We've added several new API integrations and improvements. Read below for more details!

--- a/blog/electron-11-0.md
+++ b/blog/electron-11-0.md
@@ -6,6 +6,7 @@ authors:
     url: 'https://github.com/VerteDinde'
     image_url: 'https://github.com/VerteDinde.png?size=96'
 slug: electron-11-0
+tags: [release]
 ---
 
 Electron 11.0.0 has been released! It includes upgrades to Chromium `87`, V8 `8.7`, and Node.js `12.18.3`. We've added support for Apple silicon, and general improvements. Read below for more details!

--- a/blog/electron-12-0.md
+++ b/blog/electron-12-0.md
@@ -12,6 +12,7 @@ authors:
     url: 'https://github.com/sofianguy'
     image_url: 'https://github.com/sofianguy.png?size=96'
 slug: electron-12-0
+tags: [release]
 ---
 
 Electron 12.0.0 has been released! It includes upgrades to Chromium `89`, V8 `8.9` and Node.js `14.16`. We've added changes to the remote module, new defaults for contextIsolation, a new webFrameMain API, and general improvements. Read below for more details!

--- a/blog/electron-13-0.md
+++ b/blog/electron-13-0.md
@@ -12,6 +12,7 @@ authors:
     url: 'https://github.com/VerteDinde'
     image_url: 'https://github.com/VerteDinde.png?size=96'
 slug: electron-13-0
+tags: [release]
 ---
 
 Electron 13.0.0 has been released! It includes upgrades to Chromium `91` and V8 `9.1`. We've added several API updates, bug fixes, and general improvements. Read below for more details!

--- a/blog/electron-14-0.md
+++ b/blog/electron-14-0.md
@@ -12,6 +12,7 @@ authors:
     url: 'https://github.com/ckerr'
     image_url: 'https://github.com/ckerr.png?size=96'
 slug: electron-14-0
+tags: [release]
 ---
 
 Electron 14.0.0 has been released! It includes upgrades to Chromium `93` and V8 `9.3`. We've added several API updates, bug fixes, and general improvements. Read below for more details!

--- a/blog/electron-15-0.md
+++ b/blog/electron-15-0.md
@@ -9,6 +9,7 @@ authors:
     url: 'https://github.com/vertedinde'
     image_url: 'https://github.com/vertedinde.png?size=96'
 slug: electron-15-0
+tags: [release]
 ---
 
 Electron 15.0.0 has been released! It includes upgrades to Chromium `94`, V8 `9.4`, and Node.js `16.5.0`. We've added API updates to window.open, bug fixes, and general improvements. Read below for more details!

--- a/blog/electron-16-0.md
+++ b/blog/electron-16-0.md
@@ -9,6 +9,7 @@ authors:
     url: 'https://github.com/ckerr'
     image_url: 'https://github.com/ckerr.png?size=96'
 slug: electron-16-0
+tags: [release]
 ---
 
 Electron 16.0.0 has been released! It includes upgrades to Chromium `96`, V8 `9.6`, and Node.js `16.9.1`. Read below for more details!

--- a/blog/electron-17-0.md
+++ b/blog/electron-17-0.md
@@ -9,6 +9,7 @@ authors:
     url: 'https://github.com/VerteDinde'
     image_url: 'https://github.com/VerteDinde.png?size=96'
 slug: electron-17-0
+tags: [release]
 ---
 
 Electron 17.0.0 has been released! It includes upgrades to Chromium `98`, V8 `9.8`, and Node.js `16.13.0`. Read below for more details!

--- a/blog/electron-18.md
+++ b/blog/electron-18.md
@@ -9,6 +9,7 @@ authors:
     url: 'https://github.com/sofianguy'
     image_url: 'https://github.com/sofianguy.png?size=96'
 slug: electron-18-0
+tags: [release]
 ---
 
 Electron 18.0.0 has been released! It includes upgrades to Chromium `100`, V8 `10.0`, and Node.js `16.13.2`. Read below for more details!

--- a/blog/electron-19.md
+++ b/blog/electron-19.md
@@ -9,6 +9,7 @@ authors:
     url: 'https://github.com/ckerr'
     image_url: 'https://github.com/ckerr.png?size=96'
 slug: electron-19-0
+tags: [release]
 ---
 
 Electron 19.0.0 has been released! It includes upgrades to Chromium `102`, V8 `10.2`, and Node.js `16.14.2`. Read below for more details!

--- a/blog/electron-2-0.md
+++ b/blog/electron-2-0.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/ckerr'
   image_url: 'https://github.com/ckerr.png?size=96'
 slug: electron-2-0
+tags: [release]
 ---
 
 After more than four months of development, eight beta releases, and worldwide

--- a/blog/electron-2-semantic-boogaloo.md
+++ b/blog/electron-2-semantic-boogaloo.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/groundwater'
   image_url: 'https://github.com/groundwater.png?size=96'
 slug: electron-2-semantic-boogaloo
+tags: [release]
 ---
 
 A new major version of Electron is in the works, and with it some changes to our versioning strategy. As of version 2.0.0, Electron will strictly adhere to Semantic Versioning.

--- a/blog/electron-20-0.md
+++ b/blog/electron-20-0.md
@@ -6,6 +6,7 @@ authors:
     url: 'https://github.com/ckerr'
     image_url: 'https://github.com/ckerr.png?size=96'
 slug: electron-20-0
+tags: [release]
 ---
 
 Electron 20.0.0 has been released! It includes upgrades to Chromium `104`, V8 `10.4`, and Node.js `16.15.0`. Read below for more details!

--- a/blog/electron-21-0.md
+++ b/blog/electron-21-0.md
@@ -12,6 +12,7 @@ authors:
     url: 'https://github.com/georgexu99'
     image_url: 'https://github.com/georgexu99.png?size=96'
 slug: electron-21-0
+tags: [release]
 ---
 
 Electron 21.0.0 has been released! It includes upgrades to Chromium `106`, V8 `10.6`, and Node.js `16.16.0`. Read below for more details!

--- a/blog/electron-22-0.md
+++ b/blog/electron-22-0.md
@@ -9,6 +9,7 @@ authors:
     url: 'https://github.com/georgexu99'
     image_url: 'https://github.com/georgexu99.png?size=96'
 slug: electron-22-0
+tags: [release]
 ---
 
 Electron 22.0.0 has been released! It includes a new utility process API, updates for Windows 7/8/8.1 support, and upgrades to Chromium `108`, V8 `10.8`, and Node.js `16.17.1`. Read below for more details!

--- a/blog/electron-23-0.md
+++ b/blog/electron-23-0.md
@@ -12,6 +12,7 @@ authors:
     url: 'https://github.com/erickzhao'
     image_url: 'https://github.com/erickzhao.png?size=96'
 slug: electron-23-0
+tags: [release]
 ---
 
 Electron 23.0.0 has been released! It includes upgrades to Chromium `110`, V8 `11.0`, and Node.js `18.12.1`. Additionally, support for Windows 7/8/8.1 has been dropped. Read below for more details!

--- a/blog/electron-24-0.md
+++ b/blog/electron-24-0.md
@@ -6,6 +6,7 @@ authors:
     url: 'https://github.com/georgexu99'
     image_url: 'https://github.com/georgexu99.png?size=96'
 slug: electron-24-0
+tags: [release]
 ---
 
 Electron 24.0.0 has been released! It includes upgrades to Chromium `112.0.5615.49`, V8 `11.2`, and Node.js `18.14.0`. Read below for more details!

--- a/blog/electron-25-0.md
+++ b/blog/electron-25-0.md
@@ -9,6 +9,7 @@ authors:
     url: 'https://github.com/vertedinde'
     image_url: 'https://github.com/vertedinde.png?size=96'
 slug: electron-25-0
+tags: [release]
 ---
 
 Electron 25.0.0 has been released! It includes upgrades to Chromium `114`, V8 `11.4`, and Node.js `18.15.0`. Read below for more details!

--- a/blog/electron-26-0.md
+++ b/blog/electron-26-0.md
@@ -6,6 +6,7 @@ authors:
     url: 'https://github.com/vertedinde'
     image_url: 'https://github.com/vertedinde.png?size=96'
 slug: electron-26-0
+tags: [release]
 ---
 
 Electron 26.0.0 has been released! It includes upgrades to Chromium `116.0.5845.62`, V8 `11.2`, and Node.js `18.16.1`. Read below for more details!

--- a/blog/electron-27-0.md
+++ b/blog/electron-27-0.md
@@ -6,6 +6,7 @@ authors:
     url: 'https://github.com/vertedinde'
     image_url: 'https://github.com/vertedinde.png?size=96'
 slug: electron-27-0
+tags: [release]
 ---
 
 Electron 27.0.0 has been released! It includes upgrades to Chromium `118.0.5993.32`, V8 `11.8`, and Node.js `18.17.1`.

--- a/blog/electron-28-0.md
+++ b/blog/electron-28-0.md
@@ -6,6 +6,7 @@ authors:
     url: 'https://github.com/ckerr'
     image_url: 'https://github.com/ckerr.png?size=96'
 slug: electron-28-0
+tags: [release]
 ---
 
 Electron 28.0.0 has been released! It includes upgrades to Chromium `120.0.6099.56`, V8 `12.0`, and Node.js `18.18.2`.

--- a/blog/electron-29-0.md
+++ b/blog/electron-29-0.md
@@ -6,6 +6,7 @@ authors:
     url: 'https://github.com/vertedinde'
     image_url: 'https://github.com/vertedinde.png?size=96'
 slug: electron-29-0
+tags: [release]
 ---
 
 Electron 29.0.0 has been released! It includes upgrades to Chromium `122.0.6261.39`, V8 `12.2`, and Node.js `20.9.0`.

--- a/blog/electron-3-0.md
+++ b/blog/electron-3-0.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/codebytere'
   image_url: 'https://github.com/codebytere.png?size=96'
 slug: electron-3-0
+tags: [release]
 ---
 
 The Electron team is excited to announce that the first stable release of Electron 3 is now

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -9,6 +9,7 @@ authors:
     url: 'https://github.com/vertedinde'
     image_url: 'https://github.com/vertedinde.png?size=96'
 slug: electron-30-0
+tags: [release]
 ---
 
 Electron 30.0.0 has been released! It includes upgrades to Chromium `124.0.6367.49`, V8 `12.4`, and Node.js `20.11.1`.

--- a/blog/electron-31-0.md
+++ b/blog/electron-31-0.md
@@ -6,6 +6,7 @@ authors:
     url: 'https://github.com/vertedinde'
     image_url: 'https://github.com/vertedinde.png?size=96'
 slug: electron-31-0
+tags: [release]
 ---
 
 Electron 31.0.0 has been released! It includes upgrades to Chromium `126.0.6478.36`, V8 `12.6`, and Node `20.14.0`.

--- a/blog/electron-37.md
+++ b/blog/electron-37.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/zeke'
   image_url: 'https://github.com/zeke.png?size=96'
 slug: electron-37
+tags: [release]
 ---
 
 Electron `0.37` was recently [released](https://github.com/electron/electron/releases) and included a major upgrade from Chrome 47 to Chrome 49 and also several new core APIs. This latest release brings in all the new features shipped in [Chrome 48](http://blog.chromium.org/2015/12/chrome-48-beta-present-to-cast-devices_91.html) and [Chrome 49](http://blog.chromium.org/2016/02/chrome-49-beta-css-custom-properties.html). This includes CSS custom properties, increased [ES6](http://www.ecma-international.org/ecma-262/6.0/) support, `KeyboardEvent` improvements, `Promise` improvements, and many other new features now available in your Electron app.

--- a/blog/electron-4-0.md
+++ b/blog/electron-4-0.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/BinaryMuse'
   image_url: 'https://github.com/BinaryMuse.png?size=96'
 slug: electron-4-0
+tags: [release]
 ---
 
 The Electron team is excited to announce that the stable release of Electron 4 is now available! You can install it from [electronjs.org](https://electronjs.org/) or from npm via `npm install electron@latest`. The release is packed with upgrades, fixes, and new features, and we can't wait to see what you build with them. Read more for details about this release, and please share any feedback you have as you explore!

--- a/blog/electron-5-0-timeline.md
+++ b/blog/electron-5-0-timeline.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/sofianguy'
   image_url: 'https://github.com/sofianguy.png?size=96'
 slug: electron-5-0-timeline
+tags: [release]
 ---
 
 For the first time ever, Electron is excited to publicize our release schedule starting with v5.0.0. This is our first step in having a public, long-term timeline.

--- a/blog/electron-5-0.md
+++ b/blog/electron-5-0.md
@@ -12,6 +12,7 @@ authors:
     url: 'https://github.com/jkleinsc'
     image_url: 'https://github.com/jkleinsc.png?size=96'
 slug: electron-5-0
+tags: [release]
 ---
 
 The Electron team is excited to announce the release of Electron 5.0.0! You can install it with npm via `npm install electron@latest` or download the tarballs from [our releases page](https://github.com/electron/electron/releases/tag/v5.0.0). The release is packed with upgrades, fixes, and new features. We can't wait to see what you build with them! Continue reading for details about this release, and please share any feedback you have!

--- a/blog/electron-6-0.md
+++ b/blog/electron-6-0.md
@@ -12,6 +12,7 @@ authors:
     url: 'https://github.com/codebytere'
     image_url: 'https://github.com/codebytere.png?size=96'
 slug: electron-6-0
+tags: [release]
 ---
 
 The Electron team is excited to announce the release of Electron 6.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://electronjs.org/releases/stable). The release is packed with upgrades, fixes, and new features. We can't wait to see what you build with them! Continue reading for details about this release, and please share any feedback you have!

--- a/blog/electron-7-0.md
+++ b/blog/electron-7-0.md
@@ -9,6 +9,7 @@ authors:
     url: 'https://github.com/ckerr'
     image_url: 'https://github.com/ckerr.png?size=96'
 slug: electron-7-0
+tags: [release]
 ---
 
 Electron 7.0.0 has been released! It includes upgrades to Chromium 78, V8 7.8, and Node.js 12.8.1. We've added a Window on Arm 64 release, faster IPC methods, a new `nativeTheme` API, and much more!

--- a/blog/electron-8-0.md
+++ b/blog/electron-8-0.md
@@ -9,6 +9,7 @@ authors:
     url: 'https://github.com/sofianguy'
     image_url: 'https://github.com/sofianguy.png?size=96'
 slug: electron-8-0
+tags: [release]
 ---
 
 Electron 8.0.0 has been released! It includes upgrades to Chromium `80`, V8 `8.0`, and Node.js `12.13.0`. We've added Chrome's built-in spellchecker, and much more!

--- a/blog/electron-9-0.md
+++ b/blog/electron-9-0.md
@@ -9,6 +9,7 @@ authors:
     url: 'https://github.com/VerteDinde'
     image_url: 'https://github.com/VerteDinde.png?size=96'
 slug: electron-9-0
+tags: [release]
 ---
 
 Electron 9.0.0 has been released! It includes upgrades to Chromium `83`, V8 `8.3`, and Node.js `12.14`. We've added several new API integrations for our spellchecker feature, enabled PDF viewer, and much more!

--- a/blog/magellan-fix.md
+++ b/blog/magellan-fix.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/ckerr'
   image_url: 'https://github.com/ckerr.png?size=96'
 slug: magellan-fix
+tags: [security]
 ---
 
 A remote code execution vulnerability, "[Magellan](https://blade.tencent.com/magellan/index_en.html)," has been discovered affecting software based on SQLite or Chromium, including all versions of Electron.

--- a/blog/protocol-handler-fix.md
+++ b/blog/protocol-handler-fix.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/zeke'
   image_url: 'https://github.com/zeke.png?size=96'
 slug: protocol-handler-fix
+tags: [security]
 ---
 
 A remote code execution vulnerability has been discovered affecting

--- a/blog/run-as-node-cves.md
+++ b/blog/run-as-node-cves.md
@@ -9,6 +9,7 @@ authors:
     url: 'https://github.com/felixrieseberg'
     image_url: 'https://github.com/felixrieseberg.png?size=96'
 slug: statement-run-as-node-cves
+tags: [security]
 ---
 
 Earlier today, the Electron team was alerted to several public CVEs recently filed against several notable Electron apps. The CVEs are related to two of Electron’s [fuses](https://www.electronjs.org/docs/latest/tutorial/fuses) - `runAsNode` and `enableNodeCliInspectArguments` - and incorrectly claim that a remote attacker is able to execute arbitrary code via these components if they have not been actively disabled.

--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -1,0 +1,4 @@
+release:
+  description: 'Blog posts about new Electron releases'
+security:
+  description: 'Blog posts related to security'

--- a/blog/web-preferences-fix.md
+++ b/blog/web-preferences-fix.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/ckerr'
   image_url: 'https://github.com/ckerr.png?size=96'
 slug: web-preferences-fix
+tags: [security]
 ---
 
 A remote code execution vulnerability has been discovered affecting apps with the ability to open nested child windows on Electron versions (3.0.0-beta.6, 2.0.7, 1.8.7, and 1.7.15). This vulnerability has been assigned the CVE identifier [CVE-2018-15685].

--- a/blog/webview-fix.md
+++ b/blog/webview-fix.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/ckerr'
   image_url: 'https://github.com/ckerr.png?size=96'
 slug: webview-fix
+tags: [security]
 ---
 
 A vulnerability has been discovered which allows Node.js integration to be re-enabled in some Electron applications that disable it. This vulnerability has been assigned the CVE identifier [CVE-2018-1000136](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000136).

--- a/blog/window-open-fix.md
+++ b/blog/window-open-fix.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/ckerr'
   image_url: 'https://github.com/ckerr.png?size=96'
 slug: window-open-fix
+tags: [security]
 ---
 
 A code vulnerability has been discovered that allows Node to be re-enabled in child windows.


### PR DESCRIPTION
Stacked on #575.

Adds a `blog/tags.yml` file to define two tags (`release` and `security`) and backfills tags for relevant blog posts. Makes it easier to find blog posts related to those topics, especially since the sidebar only displays the last 50 posts (although we can control this via config).