### PR TITLE
chore: add blog global authors

### DIFF
--- a/blog/10-years-of-electron.md
+++ b/blog/10-years-of-electron.md
@@ -1,10 +1,7 @@
 ---
 title: 10 years of Electron 🎉
 date: 2023-03-13T00:00:00.000Z
-authors:
-  name: erickzhao
-  url: 'https://github.com/erickzhao'
-  image_url: 'https://github.com/erickzhao.png?size=96'
+authors: erickzhao
 slug: 10-years-of-electron
 ---
 

--- a/blog/12-week-cadence.md
+++ b/blog/12-week-cadence.md
@@ -1,10 +1,7 @@
 ---
 title: New Electron Release Cadence
 date: 2019-05-13T00:00:00.000Z
-authors:
-  name: sofianguy
-  url: 'https://github.com/sofianguy'
-  image_url: 'https://github.com/sofianguy.png?size=96'
+authors: sofianguy
 slug: 12-week-cadence
 ---
 

--- a/blog/2015-whats-new-in-electron.md
+++ b/blog/2015-whats-new-in-electron.md
@@ -1,10 +1,7 @@
 ---
 title: What's New in Electron
 date: 2015-10-15T00:00:00.000Z
-authors:
-  name: jlord
-  url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=96'
+authors: jlord
 slug: 2015-whats-new-in-electron
 ---
 

--- a/blog/2020-season-of-docs.md
+++ b/blog/2020-season-of-docs.md
@@ -1,10 +1,7 @@
 ---
 title: Google Season of Docs
 date: 2020-05-21T00:00:00.000Z
-authors:
-  - name: erickzhao
-    url: 'https://github.com/erickzhao'
-    image_url: 'https://github.com/erickzhao.png?size=96'
+authors: erickzhao
 slug: 2020-season-of-docs
 ---
 

--- a/blog/2022-maintainer-summit.md
+++ b/blog/2022-maintainer-summit.md
@@ -1,10 +1,7 @@
 ---
 title: Maintainer Summit 2022 Recap
 date: 2022-10-13T00:00:00.000Z
-authors:
-  - name: erickzhao
-    url: 'https://github.com/erickzhao'
-    image_url: 'https://github.com/erickzhao.png?size=96'
+authors: erickzhao
 slug: maintainer-summit-2022-recap
 ---
 

--- a/blog/2022-summer-of-code.md
+++ b/blog/2022-summer-of-code.md
@@ -2,18 +2,10 @@
 title: Google Summer of Code 2022
 date: 2022-03-07T00:00:00.000Z
 authors:
-  - name: erickzhao
-    url: 'https://github.com/erickzhao'
-    image_url: 'https://github.com/erickzhao.png?size=96'
-  - name: sofianguy
-    url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=96'
-  - name: dsanders11
-    url: 'https://github.com/dsanders11'
-    image_url: 'https://github.com/dsanders11.png?size=96'
-  - name: vertedinde
-    url: 'https://github.com/vertedinde'
-    image_url: 'https://github.com/vertedinde.png?size=96'
+  - erickzhao
+  - sofianguy
+  - dsanders11
+  - VerteDinde
 slug: 2022-summer-of-code
 ---
 

--- a/blog/2023-ecosystem-eoy-recap.md
+++ b/blog/2023-ecosystem-eoy-recap.md
@@ -1,10 +1,7 @@
 ---
 title: Ecosystem 2023 Recap
 date: 2023-11-30T00:00:00.000Z
-authors:
-  - name: erickzhao
-    url: 'https://github.com/erickzhao'
-    image_url: 'https://github.com/erickzhao.png?size=96'
+authors: erickzhao
 slug: ecosystem-2023-eoy-recap
 ---
 

--- a/blog/2024-summer-of-code.md
+++ b/blog/2024-summer-of-code.md
@@ -2,15 +2,9 @@
 title: Google Summer of Code 2024
 date: 2024-02-23T00:00:00.000Z
 authors:
-  - name: erickzhao
-    url: 'https://github.com/erickzhao'
-    image_url: 'https://github.com/erickzhao.png?size=96'
-  - name: VerteDinde
-    url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=96'
-  - name: dsanders11
-    url: 'https://github.com/dsanders11'
-    image_url: 'https://github.com/dsanders11.png?size=96'
+  - erickzhao
+  - VerteDinde
+  - dsanders11
 slug: 2024-summer-of-code
 ---
 

--- a/blog/8-week-cadence.md
+++ b/blog/8-week-cadence.md
@@ -1,10 +1,7 @@
 ---
 title: New Electron Release Cadence
 date: 2021-07-14T00:00:00.000Z
-authors:
-  name: VerteDinde
-  url: 'https://github.com/VerteDinde'
-  image_url: 'https://github.com/VerteDinde.png?size=96'
+authors: VerteDinde
 slug: 8-week-cadence
 ---
 

--- a/blog/accessibility-tools.md
+++ b/blog/accessibility-tools.md
@@ -1,10 +1,7 @@
 ---
 title: Accessibility Tools
 date: 2016-08-23T00:00:00.000Z
-authors:
-  name: jlord
-  url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=96'
+authors: jlord
 slug: accessibility-tools
 ---
 

--- a/blog/api-docs-json-schema.md
+++ b/blog/api-docs-json-schema.md
@@ -1,10 +1,7 @@
 ---
 title: Electron's API Docs as Structured Data
 date: 2016-09-27T00:00:00.000Z
-authors:
-  name: zeke
-  url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=96'
+authors: zeke
 slug: api-docs-json-schema
 ---
 

--- a/blog/app-feedback-program.md
+++ b/blog/app-feedback-program.md
@@ -1,10 +1,7 @@
 ---
 title: Electron App Feedback Program
 date: 2018-10-02T00:00:00.000Z
-authors:
-  name: sofianguy
-  url: 'https://github.com/sofianguy'
-  image_url: 'https://github.com/sofianguy.png?size=96'
+authors: sofianguy
 slug: app-feedback-program
 ---
 

--- a/blog/apple-silicon.md
+++ b/blog/apple-silicon.md
@@ -1,10 +1,7 @@
 ---
 title: Apple Silicon Support
 date: 2020-10-15T00:00:00.000Z
-authors:
-  name: MarshallOfSound
-  url: 'https://github.com/MarshallOfSound'
-  image_url: 'https://github.com/MarshallOfSound.png?size=96'
+authors: MarshallOfSound
 slug: apple-silicon
 ---
 

--- a/blog/august-2016-roundup.md
+++ b/blog/august-2016-roundup.md
@@ -1,10 +1,7 @@
 ---
 title: 'August 2016: New Apps'
 date: 2016-09-06T00:00:00.000Z
-authors:
-  name: jlord
-  url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=96'
+authors: jlord
 slug: august-2016-roundup
 ---
 

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,0 +1,79 @@
+clavin:
+  name: clavin
+  url: https://github.com/clavin
+  image_url: https://github.com/clavin.png?size=96
+
+ckerr:
+  name: ckerr
+  url: https://github.com/ckerr
+  image_url: https://github.com/ckerr.png?size=96
+
+codebytere:
+  name: codebytere
+  url: https://github.com/codebytere
+  image_url: https://github.com/codebytere.png?size=96
+
+dsanders11:
+  name: dsanders11
+  url: https://github.com/dsanders11
+  image_url: https://github.com/dsanders11.png?size=96
+
+erickzhao:
+  name: erickzhao
+  url: https://github.com/erickzhao
+  image_url: https://github.com/erickzhao.png?size=96
+
+felixrieseberg:
+  name: felixrieseberg
+  url: https://github.com/felixrieseberg
+  image_url: https://github.com/felixrieseberg.png?size=96
+
+georgexu99:
+  name: georgexu99
+  url: https://github.com/georgexu99
+  image_url: https://github.com/georgexu99.png?size=96
+
+jlord:
+  name: jlord
+  url: https://github.com/jlord
+  image_url: https://github.com/jlord.png?size=96
+
+jkleinsc:
+  name: jkleinsc
+  url: https://github.com/jkleinsc
+  image_url: https://github.com/jkleinsc.png?size=96
+
+MarshallOfSound:
+  name: MarshallOfSound
+  url: https://github.com/MarshallOfSound
+  image_url: https://github.com/MarshallOfSound.png?size=96
+
+mlaurencin:
+  name: mlaurencin
+  url: https://github.com/mlaurencin
+  image_url: https://github.com/mlaurencin.png?size=96
+
+nornagon:
+  name: nornagon
+  url: https://github.com/nornagon
+  image_url: https://github.com/nornagon.png?size=96
+
+sofianguy:
+  name: sofianguy
+  url: https://github.com/sofianguy
+  image_url: https://github.com/sofianguy.png?size=96
+
+VerteDinde:
+  name: VerteDinde
+  url: https://github.com/VerteDinde
+  image_url: https://github.com/VerteDinde.png?size=96
+
+zcbenz:
+  name: zcbenz
+  url: https://github.com/zcbenz
+  image_url: https://github.com/zcbenz.png?size=96
+
+zeke:
+  name: zeke
+  url: https://github.com/zeke
+  image_url: https://github.com/zeke.png?size=96

--- a/blog/autoupdating-electron-apps.md
+++ b/blog/autoupdating-electron-apps.md
@@ -1,10 +1,7 @@
 ---
 title: Easier AutoUpdating for Open-Source Apps
 date: 2018-05-01T00:00:00.000Z
-authors:
-  name: zeke
-  url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=96'
+authors: zeke
 slug: autoupdating-electron-apps
 ---
 

--- a/blog/beaker-browser.md
+++ b/blog/beaker-browser.md
@@ -5,9 +5,7 @@ authors:
   - name: pfrazee
     url: 'https://github.com/pfrazee'
     image_url: 'https://github.com/pfrazee.png?size=96'
-  - name: zeke
-    url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=96'
+  - zeke
 slug: beaker-browser
 ---
 

--- a/blog/breach-to-barrier.md
+++ b/blog/breach-to-barrier.md
@@ -1,10 +1,7 @@
 ---
 title: 'Breach to Barrier: Strengthening Apps with the Sandbox'
 date: 2023-09-29T00:00:00.000Z
-authors:
-  - name: felixrieseberg
-    url: 'https://github.com/felixrieseberg'
-    image_url: 'https://github.com/felixrieseberg.png?size=96'
+authors: felixrieseberg
 slug: breach-to-barrier
 tags: [security]
 ---

--- a/blog/cadence-pause.md
+++ b/blog/cadence-pause.md
@@ -1,10 +1,7 @@
 ---
 title: Upcoming Electron Releases
 date: 2020-03-19T00:00:00.000Z
-authors:
-  name: codebytere
-  url: 'https://github.com/codebytere'
-  image_url: 'https://github.com/codebytere.png?size=96'
+authors: codebytere
 slug: cadence-pause
 ---
 

--- a/blog/chromium-rce-vulnerability.md
+++ b/blog/chromium-rce-vulnerability.md
@@ -1,10 +1,7 @@
 ---
 title: Chromium RCE Vulnerability Fix
 date: 2017-09-27T00:00:00.000Z
-authors:
-  name: zeke
-  url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=96'
+authors: zeke
 slug: chromium-rce-vulnerability
 tags: [security]
 ---

--- a/blog/cve-2019-13720.md
+++ b/blog/cve-2019-13720.md
@@ -1,10 +1,7 @@
 ---
 title: Chromium WebAudio Vulnerability Fix (CVE-2019-13720)
 date: 2019-11-04T00:00:00.000Z
-authors:
-  name: nornagon
-  url: 'https://github.com/nornagon'
-  image_url: 'https://github.com/nornagon.png?size=96'
+authors: nornagon
 slug: cve-2019-13720
 tags: [security]
 ---

--- a/blog/dat.md
+++ b/blog/dat.md
@@ -11,9 +11,7 @@ authors:
   - name: maxogden
     url: 'https://github.com/maxogden'
     image_url: 'https://github.com/maxogden.png?size=96'
-  - name: zeke
-    url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=96'
+  - zeke
 slug: dat
 ---
 

--- a/blog/dec-quiet-period-23.md
+++ b/blog/dec-quiet-period-23.md
@@ -5,9 +5,7 @@ authors:
   - name: PlaineKevin
     url: 'https://github.com/PlaineKevin'
     image_url: 'https://github.com/PlaineKevin.png?size=96'
-  - name: erickzhao
-    url: 'https://github.com/erickzhao'
-    image_url: 'https://github.com/erickzhao.png?size=96'
+  - erickzhao
 slug: dec-quiet-period-23
 ---
 

--- a/blog/discord-hacktoberfest-2020.md
+++ b/blog/discord-hacktoberfest-2020.md
@@ -1,10 +1,7 @@
 ---
 title: Community Discord Server and Hacktoberfest
 date: 2020-10-01T00:00:00.000Z
-authors:
-  - name: erickzhao
-    url: 'https://github.com/erickzhao'
-    image_url: 'https://github.com/erickzhao.png?size=96'
+authors: erickzhao
 slug: discord-hacktoberfest-2020
 ---
 

--- a/blog/electron-1-0.md
+++ b/blog/electron-1-0.md
@@ -1,10 +1,7 @@
 ---
 title: Electron 1.0
 date: 2016-05-11T00:00:00.000Z
-authors:
-  name: jlord
-  url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=96'
+authors: jlord
 slug: electron-1-0
 tags: [release]
 ---

--- a/blog/electron-10-0.md
+++ b/blog/electron-10-0.md
@@ -2,12 +2,8 @@
 title: Electron 10.0.0
 date: 2020-08-25T00:00:00.000Z
 authors:
-  - name: VerteDinde
-    url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=96'
-  - name: sofianguy
-    url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=96'
+  - VerteDinde
+  - sofianguy
 slug: electron-10-0
 tags: [release]
 ---

--- a/blog/electron-11-0.md
+++ b/blog/electron-11-0.md
@@ -1,10 +1,7 @@
 ---
 title: Electron 11.0.0
 date: 2020-11-17T00:00:00.000Z
-authors:
-  - name: VerteDinde
-    url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=96'
+authors: VerteDinde
 slug: electron-11-0
 tags: [release]
 ---

--- a/blog/electron-12-0.md
+++ b/blog/electron-12-0.md
@@ -2,15 +2,9 @@
 title: Electron 12.0.0
 date: 2021-03-02T00:00:00.000Z
 authors:
-  - name: VerteDinde
-    url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=96'
-  - name: mlaurencin
-    url: 'https://github.com/mlaurencin'
-    image_url: 'https://github.com/mlaurencin.png?size=96'
-  - name: sofianguy
-    url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=96'
+  - VerteDinde
+  - mlaurencin
+  - sofianguy
 slug: electron-12-0
 tags: [release]
 ---

--- a/blog/electron-13-0.md
+++ b/blog/electron-13-0.md
@@ -2,15 +2,9 @@
 title: Electron 13.0.0
 date: 2021-05-25T00:00:00.000Z
 authors:
-  - name: sofianguy
-    url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=96'
-  - name: georgexu99
-    url: 'https://github.com/georgexu99'
-    image_url: 'https://github.com/georgexu99.png?size=96'
-  - name: VerteDinde
-    url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=96'
+  - sofianguy
+  - georgexu99
+  - VerteDinde
 slug: electron-13-0
 tags: [release]
 ---

--- a/blog/electron-14-0.md
+++ b/blog/electron-14-0.md
@@ -2,15 +2,9 @@
 title: Electron 14.0.0
 date: 2021-08-31T00:00:00.000Z
 authors:
-  - name: sofianguy
-    url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=96'
-  - name: clavin
-    url: 'https://github.com/clavin'
-    image_url: 'https://github.com/clavin.png?size=96'
-  - name: ckerr
-    url: 'https://github.com/ckerr'
-    image_url: 'https://github.com/ckerr.png?size=96'
+  - sofianguy
+  - clavin
+  - ckerr
 slug: electron-14-0
 tags: [release]
 ---

--- a/blog/electron-15-0.md
+++ b/blog/electron-15-0.md
@@ -2,12 +2,8 @@
 title: Electron 15.0.0
 date: 2021-09-21T00:00:00.000Z
 authors:
-  - name: sofianguy
-    url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=96'
-  - name: vertedinde
-    url: 'https://github.com/vertedinde'
-    image_url: 'https://github.com/vertedinde.png?size=96'
+  - sofianguy
+  - VerteDinde
 slug: electron-15-0
 tags: [release]
 ---

--- a/blog/electron-16-0.md
+++ b/blog/electron-16-0.md
@@ -2,12 +2,8 @@
 title: Electron 16.0.0
 date: 2021-11-16T00:00:00.000Z
 authors:
-  - name: sofianguy
-    url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=96'
-  - name: ckerr
-    url: 'https://github.com/ckerr'
-    image_url: 'https://github.com/ckerr.png?size=96'
+  - sofianguy
+  - ckerr
 slug: electron-16-0
 tags: [release]
 ---

--- a/blog/electron-17-0.md
+++ b/blog/electron-17-0.md
@@ -2,12 +2,8 @@
 title: Electron 17.0.0
 date: 2022-02-01T00:00:00.000Z
 authors:
-  - name: mlaurencin
-    url: 'https://github.com/mlaurencin'
-    image_url: 'https://github.com/mlaurencin.png?size=96'
-  - name: VerteDinde
-    url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=96'
+  - mlaurencin
+  - VerteDinde
 slug: electron-17-0
 tags: [release]
 ---

--- a/blog/electron-18.md
+++ b/blog/electron-18.md
@@ -2,12 +2,8 @@
 title: Electron 18.0.0
 date: 2022-03-29T00:00:00.000Z
 authors:
-  - name: VerteDinde
-    url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=96'
-  - name: sofianguy
-    url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=96'
+  - VerteDinde
+  - sofianguy
 slug: electron-18-0
 tags: [release]
 ---

--- a/blog/electron-19.md
+++ b/blog/electron-19.md
@@ -2,12 +2,8 @@
 title: Electron 19.0.0
 date: 2022-05-24T00:00:00.000Z
 authors:
-  - name: VerteDinde
-    url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=96'
-  - name: ckerr
-    url: 'https://github.com/ckerr'
-    image_url: 'https://github.com/ckerr.png?size=96'
+  - VerteDinde
+  - ckerr
 slug: electron-19-0
 tags: [release]
 ---

--- a/blog/electron-2-0.md
+++ b/blog/electron-2-0.md
@@ -1,10 +1,7 @@
 ---
 title: Electron 2.0.0
 date: 2018-05-02T00:00:00.000Z
-authors:
-  name: ckerr
-  url: 'https://github.com/ckerr'
-  image_url: 'https://github.com/ckerr.png?size=96'
+authors: ckerr
 slug: electron-2-0
 tags: [release]
 ---

--- a/blog/electron-20-0.md
+++ b/blog/electron-20-0.md
@@ -1,10 +1,7 @@
 ---
 title: Electron 20.0.0
 date: 2022-08-02T00:00:00.000Z
-authors:
-  - name: ckerr
-    url: 'https://github.com/ckerr'
-    image_url: 'https://github.com/ckerr.png?size=96'
+authors: ckerr
 slug: electron-20-0
 tags: [release]
 ---

--- a/blog/electron-21-0.md
+++ b/blog/electron-21-0.md
@@ -2,15 +2,9 @@
 title: Electron 21.0.0
 date: 2022-09-27T00:00:00.000Z
 authors:
-  - name: ckerr
-    url: 'https://github.com/ckerr'
-    image_url: 'https://github.com/ckerr.png?size=96'
-  - name: vertedinde
-    url: 'https://github.com/vertedinde'
-    image_url: 'https://github.com/vertedinde.png?size=96'
-  - name: georgexu99
-    url: 'https://github.com/georgexu99'
-    image_url: 'https://github.com/georgexu99.png?size=96'
+  - ckerr
+  - VerteDinde
+  - georgexu99
 slug: electron-21-0
 tags: [release]
 ---

--- a/blog/electron-22-0.md
+++ b/blog/electron-22-0.md
@@ -2,12 +2,8 @@
 title: Electron 22.0.0
 date: 2022-11-29T00:00:00.000Z
 authors:
-  - name: VerteDinde
-    url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/vertedinde.png?size=96'
-  - name: georgexu99
-    url: 'https://github.com/georgexu99'
-    image_url: 'https://github.com/georgexu99.png?size=96'
+  - VerteDinde
+  - georgexu99
 slug: electron-22-0
 tags: [release]
 ---

--- a/blog/electron-23-0.md
+++ b/blog/electron-23-0.md
@@ -2,15 +2,9 @@
 title: Electron 23.0.0
 date: 2023-2-07T00:00:00.000Z
 authors:
-  - name: VerteDinde
-    url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/vertedinde.png?size=96'
-  - name: georgexu99
-    url: 'https://github.com/georgexu99'
-    image_url: 'https://github.com/georgexu99.png?size=96'
-  - name: erickzhao
-    url: 'https://github.com/erickzhao'
-    image_url: 'https://github.com/erickzhao.png?size=96'
+  - VerteDinde
+  - georgexu99
+  - erickzhao
 slug: electron-23-0
 tags: [release]
 ---

--- a/blog/electron-24-0.md
+++ b/blog/electron-24-0.md
@@ -1,10 +1,7 @@
 ---
 title: Electron 24.0.0
 date: 2023-04-04T00:00:00.000Z
-authors:
-  - name: georgexu99
-    url: 'https://github.com/georgexu99'
-    image_url: 'https://github.com/georgexu99.png?size=96'
+authors: georgexu99
 slug: electron-24-0
 tags: [release]
 ---

--- a/blog/electron-25-0.md
+++ b/blog/electron-25-0.md
@@ -2,12 +2,8 @@
 title: Electron 25.0.0
 date: 2023-05-30T00:00:00.000Z
 authors:
-  - name: georgexu99
-    url: 'https://github.com/georgexu99'
-    image_url: 'https://github.com/georgexu99.png?size=96'
-  - name: vertedinde
-    url: 'https://github.com/vertedinde'
-    image_url: 'https://github.com/vertedinde.png?size=96'
+  - georgexu99
+  - VerteDinde
 slug: electron-25-0
 tags: [release]
 ---

--- a/blog/electron-26-0.md
+++ b/blog/electron-26-0.md
@@ -1,10 +1,7 @@
 ---
 title: Electron 26.0.0
 date: 2023-08-15T00:00:00.000Z
-authors:
-  - name: vertedinde
-    url: 'https://github.com/vertedinde'
-    image_url: 'https://github.com/vertedinde.png?size=96'
+authors: VerteDinde
 slug: electron-26-0
 tags: [release]
 ---

--- a/blog/electron-27-0.md
+++ b/blog/electron-27-0.md
@@ -1,10 +1,7 @@
 ---
 title: Electron 27.0.0
 date: 2023-10-10T00:00:00.000Z
-authors:
-  - name: vertedinde
-    url: 'https://github.com/vertedinde'
-    image_url: 'https://github.com/vertedinde.png?size=96'
+authors: VerteDinde
 slug: electron-27-0
 tags: [release]
 ---

--- a/blog/electron-28-0.md
+++ b/blog/electron-28-0.md
@@ -1,10 +1,7 @@
 ---
 title: Electron 28.0.0
 date: 2023-12-06T00:00:00.000Z
-authors:
-  - name: ckerr
-    url: 'https://github.com/ckerr'
-    image_url: 'https://github.com/ckerr.png?size=96'
+authors: ckerr
 slug: electron-28-0
 tags: [release]
 ---

--- a/blog/electron-29-0.md
+++ b/blog/electron-29-0.md
@@ -1,10 +1,7 @@
 ---
 title: Electron 29.0.0
 date: 2024-02-20T00:00:00.000Z
-authors:
-  - name: vertedinde
-    url: 'https://github.com/vertedinde'
-    image_url: 'https://github.com/vertedinde.png?size=96'
+authors: VerteDinde
 slug: electron-29-0
 tags: [release]
 ---

--- a/blog/electron-3-0.md
+++ b/blog/electron-3-0.md
@@ -1,10 +1,7 @@
 ---
 title: Electron 3.0.0
 date: 2018-09-18T00:00:00.000Z
-authors:
-  name: codebytere
-  url: 'https://github.com/codebytere'
-  image_url: 'https://github.com/codebytere.png?size=96'
+authors: codebytere
 slug: electron-3-0
 tags: [release]
 ---

--- a/blog/electron-30-0.md
+++ b/blog/electron-30-0.md
@@ -2,12 +2,8 @@
 title: Electron 30.0.0
 date: 2024-04-16T00:00:00.000Z
 authors:
-  - name: clavin
-    url: 'https://github.com/clavin'
-    image_url: 'https://github.com/clavin.png?size=96'
-  - name: VerteDinde
-    url: 'https://github.com/vertedinde'
-    image_url: 'https://github.com/vertedinde.png?size=96'
+  - clavin
+  - VerteDinde
 slug: electron-30-0
 tags: [release]
 ---

--- a/blog/electron-31-0.md
+++ b/blog/electron-31-0.md
@@ -1,10 +1,7 @@
 ---
 title: Electron 31.0.0
 date: 2024-06-11T00:00:00.000Z
-authors:
-  - name: VerteDinde
-    url: 'https://github.com/vertedinde'
-    image_url: 'https://github.com/vertedinde.png?size=96'
+authors: VerteDinde
 slug: electron-31-0
 tags: [release]
 ---

--- a/blog/electron-37.md
+++ b/blog/electron-37.md
@@ -1,10 +1,7 @@
 ---
 title: What's new in Electron 0.37
 date: 2016-03-25T00:00:00.000Z
-authors:
-  name: zeke
-  url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=96'
+authors: zeke
 slug: electron-37
 tags: [release]
 ---

--- a/blog/electron-5-0-timeline.md
+++ b/blog/electron-5-0-timeline.md
@@ -1,10 +1,7 @@
 ---
 title: Electron v5.0.0 Timeline
 date: 2019-01-25T00:00:00.000Z
-authors:
-  name: sofianguy
-  url: 'https://github.com/sofianguy'
-  image_url: 'https://github.com/sofianguy.png?size=96'
+authors: sofianguy
 slug: electron-5-0-timeline
 tags: [release]
 ---

--- a/blog/electron-5-0.md
+++ b/blog/electron-5-0.md
@@ -5,12 +5,8 @@ authors:
   - name: BinaryMuse
     url: 'https://github.com/BinaryMuse'
     image_url: 'https://github.com/BinaryMuse.png?size=96'
-  - name: ckerr
-    url: 'https://github.com/ckerr'
-    image_url: 'https://github.com/ckerr.png?size=96'
-  - name: jkleinsc
-    url: 'https://github.com/jkleinsc'
-    image_url: 'https://github.com/jkleinsc.png?size=96'
+  - ckerr
+  - jkleinsc
 slug: electron-5-0
 tags: [release]
 ---

--- a/blog/electron-6-0.md
+++ b/blog/electron-6-0.md
@@ -2,15 +2,9 @@
 title: Electron 6.0.0
 date: 2019-07-30T00:00:00.000Z
 authors:
-  - name: sofianguy
-    url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=96'
-  - name: ckerr
-    url: 'https://github.com/ckerr'
-    image_url: 'https://github.com/ckerr.png?size=96'
-  - name: codebytere
-    url: 'https://github.com/codebytere'
-    image_url: 'https://github.com/codebytere.png?size=96'
+  - sofianguy
+  - ckerr
+  - codebytere
 slug: electron-6-0
 tags: [release]
 ---

--- a/blog/electron-7-0.md
+++ b/blog/electron-7-0.md
@@ -2,12 +2,8 @@
 title: Electron 7.0.0
 date: 2019-10-22T00:00:00.000Z
 authors:
-  - name: sofianguy
-    url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=96'
-  - name: ckerr
-    url: 'https://github.com/ckerr'
-    image_url: 'https://github.com/ckerr.png?size=96'
+  - sofianguy
+  - ckerr
 slug: electron-7-0
 tags: [release]
 ---

--- a/blog/electron-8-0.md
+++ b/blog/electron-8-0.md
@@ -2,12 +2,8 @@
 title: Electron 8.0.0
 date: 2020-02-04T00:00:00.000Z
 authors:
-  - name: jkleinsc
-    url: 'https://github.com/jkleinsc'
-    image_url: 'https://github.com/jkleinsc.png?size=96'
-  - name: sofianguy
-    url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=96'
+  - jkleinsc
+  - sofianguy
 slug: electron-8-0
 tags: [release]
 ---

--- a/blog/electron-9-0.md
+++ b/blog/electron-9-0.md
@@ -2,12 +2,8 @@
 title: Electron 9.0.0
 date: 2020-05-19T00:00:00.000Z
 authors:
-  - name: sofianguy
-    url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=96'
-  - name: VerteDinde
-    url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=96'
+  - sofianguy
+  - VerteDinde
 slug: electron-9-0
 tags: [release]
 ---

--- a/blog/electron-api-changes.md
+++ b/blog/electron-api-changes.md
@@ -1,10 +1,7 @@
 ---
 title: API Changes Coming in Electron 1.0
 date: 2015-11-17T00:00:00.000Z
-authors:
-  name: zcbenz
-  url: 'https://github.com/zcbenz'
-  image_url: 'https://github.com/zcbenz.png?size=96'
+authors: zcbenz
 slug: electron-api-changes
 ---
 

--- a/blog/electron-doumentation.md
+++ b/blog/electron-doumentation.md
@@ -1,10 +1,7 @@
 ---
 title: Electron Documentation
 date: 2015-06-04T00:00:00.000Z
-authors:
-  name: jlord
-  url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=96'
+authors: jlord
 slug: electron-doumentation
 ---
 

--- a/blog/electron-internals-building-chromium-as-a-library.md
+++ b/blog/electron-internals-building-chromium-as-a-library.md
@@ -1,10 +1,7 @@
 ---
 title: 'Electron Internals: Building Chromium as a Library'
 date: 2017-03-03T00:00:00.000Z
-authors:
-  name: zcbenz
-  url: 'https://github.com/zcbenz'
-  image_url: 'https://github.com/zcbenz.png?size=96'
+authors: zcbenz
 slug: electron-internals-building-chromium-as-a-library
 ---
 

--- a/blog/electron-internals-node-integration.md
+++ b/blog/electron-internals-node-integration.md
@@ -1,10 +1,7 @@
 ---
 title: 'Electron Internals: Message Loop Integration'
 date: 2016-07-28T00:00:00.000Z
-authors:
-  name: zcbenz
-  url: 'https://github.com/zcbenz'
-  image_url: 'https://github.com/zcbenz.png?size=96'
+authors: zcbenz
 slug: electron-internals-node-integration
 ---
 

--- a/blog/electron-internals-using-node-as-a-library.md
+++ b/blog/electron-internals-using-node-as-a-library.md
@@ -1,10 +1,7 @@
 ---
 title: 'Electron Internals: Using Node as a Library'
 date: 2016-08-08T00:00:00.000Z
-authors:
-  name: zcbenz
-  url: 'https://github.com/zcbenz'
-  image_url: 'https://github.com/zcbenz.png?size=96'
+authors: zcbenz
 slug: electron-internals-using-node-as-a-library
 ---
 

--- a/blog/electron-internals-weak-references.md
+++ b/blog/electron-internals-weak-references.md
@@ -1,10 +1,7 @@
 ---
 title: 'Electron Internals: Weak References'
 date: 2016-09-20T00:00:00.000Z
-authors:
-  name: zcbenz
-  url: 'https://github.com/zcbenz'
-  image_url: 'https://github.com/zcbenz.png?size=96'
+authors: zcbenz
 slug: electron-internals-weak-references
 ---
 

--- a/blog/electron-joins-openjsf.md
+++ b/blog/electron-joins-openjsf.md
@@ -1,10 +1,7 @@
 ---
 title: Electron joins the OpenJS Foundation
 date: 2019-12-11T00:00:00.000Z
-authors:
-  - name: felixrieseberg
-    url: 'https://github.com/felixrieseberg'
-    image_url: 'https://github.com/felixrieseberg.png?size=96'
+authors: felixrieseberg
 slug: electron-joins-openjsf
 ---
 

--- a/blog/electron-meetup.md
+++ b/blog/electron-meetup.md
@@ -1,10 +1,7 @@
 ---
 title: Electron Meetup at GitHub HQ
 date: 2015-09-17T00:00:00.000Z
-authors:
-  name: jlord
-  url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=96'
+authors: jlord
 slug: electron-meetup
 ---
 

--- a/blog/electron-openjs-impact-project.md
+++ b/blog/electron-openjs-impact-project.md
@@ -1,10 +1,7 @@
 ---
 title: Electron becomes an OpenJS Foundation Impact Project
 date: 2020-06-23T00:00:00.000Z
-authors:
-  - name: VerteDinde
-    url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=96'
+authors: VerteDinde
 slug: electron-openjs-impact-project
 ---
 

--- a/blog/electron-podcasts.md
+++ b/blog/electron-podcasts.md
@@ -1,10 +1,7 @@
 ---
 title: Electron Podcasts
 date: 2016-07-26T00:00:00.000Z
-authors:
-  name: jlord
-  url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=96'
+authors: jlord
 slug: electron-podcasts
 ---
 

--- a/blog/electron-updates-mac-app-store-and-windows-auto-updater.md
+++ b/blog/electron-updates-mac-app-store-and-windows-auto-updater.md
@@ -1,10 +1,7 @@
 ---
 title: Mac App Store and Windows Auto Updater on Electron
 date: 2015-11-05T00:00:00.000Z
-authors:
-  name: jlord
-  url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=96'
+authors: jlord
 slug: electron-updates-mac-app-store-and-windows-auto-updater
 ---
 

--- a/blog/filereader-fix.md
+++ b/blog/filereader-fix.md
@@ -1,10 +1,7 @@
 ---
 title: Chromium FileReader Vulnerability Fix
 date: 2019-03-07T00:00:00.000Z
-authors:
-  name: marshallofsound
-  url: 'https://github.com/marshallofsound'
-  image_url: 'https://github.com/marshallofsound.png?size=96'
+authors: MarshallOfSound
 slug: filereader-fix
 ---
 

--- a/blog/forge-v6-release.md
+++ b/blog/forge-v6-release.md
@@ -2,15 +2,9 @@
 title: Introducing Electron Forge 6
 date: 2022-11-03T00:00:00.000Z
 authors:
-  - name: georgexu99
-    url: 'https://github.com/georgexu99'
-    image_url: 'https://github.com/georgexu99.png?size=96'
-  - name: vertedinde
-    url: 'https://github.com/vertedinde'
-    image_url: 'https://github.com/vertedinde.png?size=96'
-  - name: erickzhao
-    url: 'https://github.com/erickzhao'
-    image_url: 'https://github.com/erickzhao.png?size=96'
+  - georgexu99
+  - VerteDinde
+  - erickzhao
 slug: forge-v6-release
 toc_max_heading_level: 3
 ---

--- a/blog/from-native-to-js.md
+++ b/blog/from-native-to-js.md
@@ -1,10 +1,7 @@
 ---
 title: From native to JavaScript in Electron
 date: 2019-03-19T00:00:00.000Z
-authors:
-  name: codebytere
-  url: 'https://github.com/codebytere'
-  image_url: 'https://github.com/codebytere.png?size=96'
+authors: codebytere
 slug: from-native-to-js
 ---
 

--- a/blog/ghost.md
+++ b/blog/ghost.md
@@ -2,12 +2,8 @@
 title: 'Project of the Week: Ghost'
 date: 2017-02-14T00:00:00.000Z
 authors:
-  - name: felixrieseberg
-    url: 'https://github.com/felixrieseberg'
-    image_url: 'https://github.com/felixrieseberg.png?size=96'
-  - name: zeke
-    url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=96'
+  - felixrieseberg
+  - zeke
 slug: ghost
 ---
 

--- a/blog/gn.md
+++ b/blog/gn.md
@@ -1,10 +1,7 @@
 ---
 title: Using GN to Build Electron
 date: 2018-09-05T00:00:00.000Z
-authors:
-  name: nornagon
-  url: 'https://github.com/nornagon'
-  image_url: 'https://github.com/nornagon.png?size=96'
+authors: nornagon
 slug: gn
 ---
 

--- a/blog/governance.md
+++ b/blog/governance.md
@@ -2,12 +2,8 @@
 title: Electron Governance
 date: 2019-03-18T00:00:00.000Z
 authors:
-  - name: ckerr
-    url: 'https://github.com/ckerr'
-    image_url: 'https://github.com/ckerr.png?size=96'
-  - name: sofianguy
-    url: 'https://github.com/sofianguy'
-    image_url: 'https://github.com/sofianguy.png?size=96'
+  - ckerr
+  - sofianguy
 slug: governance
 ---
 

--- a/blog/in-app-purchases.md
+++ b/blog/in-app-purchases.md
@@ -1,10 +1,7 @@
 ---
 title: 'New in Electron 2: In-App Purchases'
 date: 2018-04-04T00:00:00.000Z
-authors:
-  name: zeke
-  url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=96'
+authors: zeke
 slug: in-app-purchases
 ---
 

--- a/blog/jasper.md
+++ b/blog/jasper.md
@@ -8,9 +8,7 @@ authors:
   - name: watilde
     url: 'https://github.com/watilde'
     image_url: 'https://github.com/watilde.png?size=96'
-  - name: zeke
-    url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=96'
+  - zeke
 slug: jasper
 ---
 

--- a/blog/july-2016-roundup.md
+++ b/blog/july-2016-roundup.md
@@ -1,10 +1,7 @@
 ---
 title: 'July 2016: New Apps and Meetups'
 date: 2016-08-04T00:00:00.000Z
-authors:
-  name: jlord
-  url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=96'
+authors: jlord
 slug: july-2016-roundup
 ---
 

--- a/blog/kap.md
+++ b/blog/kap.md
@@ -8,9 +8,7 @@ authors:
   - name: sindresorhus
     url: 'https://github.com/sindresorhus'
     image_url: 'https://github.com/sindresorhus.png?size=96'
-  - name: zeke
-    url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=96'
+  - zeke
 slug: kap
 ---
 

--- a/blog/latest-v8-chromium-features.md
+++ b/blog/latest-v8-chromium-features.md
@@ -1,10 +1,7 @@
 ---
 title: Use V8 and Chromium Features in Electron
 date: 2016-01-07T00:00:00.000Z
-authors:
-  name: jlord
-  url: 'https://github.com/jlord'
-  image_url: 'https://github.com/jlord.png?size=96'
+authors: jlord
 slug: latest-v8-chromium-features
 ---
 

--- a/blog/linux-32bit-support.md
+++ b/blog/linux-32bit-support.md
@@ -1,10 +1,7 @@
 ---
 title: Discontinuing support for 32-bit Linux
 date: 2019-03-04T00:00:00.000Z
-authors:
-  name: felixrieseberg
-  url: 'https://github.com/felixrieseberg'
-  image_url: 'https://github.com/felixrieseberg.png?size=96'
+authors: felixrieseberg
 slug: linux-32bit-support
 ---
 

--- a/blog/magellan-fix.md
+++ b/blog/magellan-fix.md
@@ -1,10 +1,7 @@
 ---
 title: SQLite Vulnerability Fix
 date: 2018-12-18T00:00:00.000Z
-authors:
-  name: ckerr
-  url: 'https://github.com/ckerr'
-  image_url: 'https://github.com/ckerr.png?size=96'
+authors: ckerr
 slug: magellan-fix
 tags: [security]
 ---

--- a/blog/new-website.md
+++ b/blog/new-website.md
@@ -1,10 +1,7 @@
 ---
 title: Electron's New Internationalized Website
 date: 2017-11-13T00:00:00.000Z
-authors:
-  name: zeke
-  url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=96'
+authors: zeke
 slug: new-website
 ---
 

--- a/blog/npm-install-electron.md
+++ b/blog/npm-install-electron.md
@@ -1,10 +1,7 @@
 ---
 title: npm install electron
 date: 2016-08-16T00:00:00.000Z
-authors:
-  name: zeke
-  url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=96'
+authors: zeke
 slug: npm-install-electron
 ---
 

--- a/blog/protocol-handler-fix.md
+++ b/blog/protocol-handler-fix.md
@@ -1,10 +1,7 @@
 ---
 title: Protocol Handler Vulnerability Fix
 date: 2018-01-22T00:00:00.000Z
-authors:
-  name: zeke
-  url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=96'
+authors: zeke
 slug: protocol-handler-fix
 tags: [security]
 ---

--- a/blog/rfcs.md
+++ b/blog/rfcs.md
@@ -1,10 +1,7 @@
 ---
 title: Introducing electron/rfcs
 date: 2024-02-13T12:00:00.000Z
-authors:
-  - name: erickzhao
-    url: 'https://github.com/erickzhao'
-    image_url: 'https://github.com/erickzhao.png?size=96'
+authors: erickzhao
 slug: rfcs
 ---
 

--- a/blog/run-as-node-cves.md
+++ b/blog/run-as-node-cves.md
@@ -2,12 +2,8 @@
 title: Statement regarding "runAsNode" CVEs
 date: 2024-02-07T12:00:00.000Z
 authors:
-  - name: VerteDinde
-    url: 'https://github.com/VerteDinde'
-    image_url: 'https://github.com/VerteDinde.png?size=96'
-  - name: felixrieseberg
-    url: 'https://github.com/felixrieseberg'
-    image_url: 'https://github.com/felixrieseberg.png?size=96'
+  - VerteDinde
+  - felixrieseberg
 slug: statement-run-as-node-cves
 tags: [security]
 ---

--- a/blog/s3-bucket-change.md
+++ b/blog/s3-bucket-change.md
@@ -1,10 +1,7 @@
 ---
 title: 'S3 Bucket Migration'
 date: 2022-05-06T00:00:00.000Z
-authors:
-  name: MarshallOfSound
-  url: 'https://github.com/MarshallOfSound'
-  image_url: 'https://github.com/MarshallOfSound.png?size=96'
+authors: MarshallOfSound
 ---
 
 Electron is changing its primary S3 bucket, you may need to update your build scripts

--- a/blog/search.md
+++ b/blog/search.md
@@ -8,9 +8,7 @@ authors:
   - name: vanessayuenn
     url: 'https://github.com/vanessayuenn'
     image_url: 'https://github.com/vanessayuenn.png?size=96'
-  - name: zeke
-    url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=96'
+  - zeke
 slug: search
 ---
 

--- a/blog/simple-samples.md
+++ b/blog/simple-samples.md
@@ -1,10 +1,7 @@
 ---
 title: Electron Simple Samples
 date: 2017-01-19T00:00:00.000Z
-authors:
-  name: zeke
-  url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=96'
+authors: zeke
 slug: simple-samples
 ---
 

--- a/blog/spectron-deprecation-notice.md
+++ b/blog/spectron-deprecation-notice.md
@@ -1,10 +1,7 @@
 ---
 title: Spectron Deprecation Notice
 date: 2021-12-01T00:00:00.000Z
-authors:
-  - name: vertedinde
-    url: 'https://github.com/vertedinde'
-    image_url: 'https://github.com/vertedinde.png?size=96'
+authors: VerteDinde
 slug: spectron-deprecation-notice
 ---
 

--- a/blog/typescript.md
+++ b/blog/typescript.md
@@ -1,10 +1,7 @@
 ---
 title: Announcing TypeScript support in Electron
 date: 2017-06-01T00:00:00.000Z
-authors:
-  name: zeke
-  url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=96'
+authors: zeke
 slug: typescript
 ---
 

--- a/blog/userland.md
+++ b/blog/userland.md
@@ -1,10 +1,7 @@
 ---
 title: Electron Userland
 date: 2016-12-20T00:00:00.000Z
-authors:
-  name: zeke
-  url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=96'
+authors: zeke
 slug: userland
 ---
 

--- a/blog/v8-memory-cage.md
+++ b/blog/v8-memory-cage.md
@@ -1,10 +1,7 @@
 ---
 title: Electron and the V8 Memory Cage
 date: 2022-06-30T00:00:00.000Z
-authors:
-  - name: nornagon
-    url: 'https://github.com/nornagon'
-    image_url: 'https://github.com/nornagon.png?size=96'
+authors: nornagon
 slug: v8-memory-cage
 ---
 

--- a/blog/voltra.md
+++ b/blog/voltra.md
@@ -8,9 +8,7 @@ authors:
   - name: aprileelcich
     url: 'https://github.com/aprileelcich'
     image_url: 'https://github.com/aprileelcich.png?size=96'
-  - name: zeke
-    url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=96'
+  - zeke
 slug: voltra
 ---
 

--- a/blog/web-preferences-fix.md
+++ b/blog/web-preferences-fix.md
@@ -1,10 +1,7 @@
 ---
 title: WebPreferences Vulnerability Fix
 date: 2018-08-22T00:00:00.000Z
-authors:
-  name: ckerr
-  url: 'https://github.com/ckerr'
-  image_url: 'https://github.com/ckerr.png?size=96'
+authors: ckerr
 slug: web-preferences-fix
 tags: [security]
 ---

--- a/blog/website-hiccups.md
+++ b/blog/website-hiccups.md
@@ -1,10 +1,7 @@
 ---
 title: Website Hiccups
 date: 2018-02-12T00:00:00.000Z
-authors:
-  name: zeke
-  url: 'https://github.com/zeke'
-  image_url: 'https://github.com/zeke.png?size=96'
+authors: zeke
 slug: website-hiccups
 ---
 

--- a/blog/webtorrent.md
+++ b/blog/webtorrent.md
@@ -5,9 +5,7 @@ authors:
   - name: feross
     url: 'https://github.com/feross'
     image_url: 'https://github.com/feross.png?size=96'
-  - name: zeke
-    url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=96'
+  - zeke
 slug: webtorrent
 ---
 

--- a/blog/webview-fix.md
+++ b/blog/webview-fix.md
@@ -1,10 +1,7 @@
 ---
 title: Webview Vulnerability Fix
 date: 2018-03-21T00:00:00.000Z
-authors:
-  name: ckerr
-  url: 'https://github.com/ckerr'
-  image_url: 'https://github.com/ckerr.png?size=96'
+authors: ckerr
 slug: webview-fix
 tags: [security]
 ---

--- a/blog/window-open-fix.md
+++ b/blog/window-open-fix.md
@@ -1,10 +1,7 @@
 ---
 title: BrowserView window.open() Vulnerability Fix
 date: 2019-02-03T00:00:00.000Z
-authors:
-  name: ckerr
-  url: 'https://github.com/ckerr'
-  image_url: 'https://github.com/ckerr.png?size=96'
+authors: ckerr
 slug: window-open-fix
 tags: [security]
 ---

--- a/blog/windows-7-deprecation.md
+++ b/blog/windows-7-deprecation.md
@@ -1,10 +1,7 @@
 ---
 title: Farewell, Windows 7/8/8.1
 date: 2022-11-29T00:00:00.000Z
-authors:
-  - name: vertedinde
-    url: 'https://github.com/vertedinde'
-    image_url: 'https://github.com/vertedinde.png?size=96'
+authors: VerteDinde
 slug: windows-7-to-8-1-deprecation-notice
 ---
 

--- a/blog/wordpress.md
+++ b/blog/wordpress.md
@@ -8,9 +8,7 @@ authors:
   - name: johngodley
     url: 'https://github.com/johngodley'
     image_url: 'https://github.com/johngodley.png?size=96'
-  - name: zeke
-    url: 'https://github.com/zeke'
-    image_url: 'https://github.com/zeke.png?size=96'
+  - zeke
 slug: wordpress
 ---
 


### PR DESCRIPTION
Makes use of the [blog global authors feature](https://docusaurus.io/docs/blog#global-authors) in Docusaurus to DRY up our blog posts and simplify setting authors for future posts.