### PR TITLE
blog: expand tag system

### DIFF
--- a/blog/10-years-of-electron.md
+++ b/blog/10-years-of-electron.md
@@ -3,6 +3,7 @@ title: 10 years of Electron 🎉
 date: 2023-03-13T00:00:00.000Z
 authors: erickzhao
 slug: 10-years-of-electron
+tags: [community, news]
 ---
 
 # 10 Years of Electron 🎉

--- a/blog/12-week-cadence.md
+++ b/blog/12-week-cadence.md
@@ -3,6 +3,7 @@ title: New Electron Release Cadence
 date: 2019-05-13T00:00:00.000Z
 authors: sofianguy
 slug: 12-week-cadence
+tags: [news, release]
 ---
 
 :::info ⚡️ Update (2021-07-14): We're going even faster!

--- a/blog/2015-whats-new-in-electron.md
+++ b/blog/2015-whats-new-in-electron.md
@@ -3,6 +3,7 @@ title: What's New in Electron
 date: 2015-10-15T00:00:00.000Z
 authors: jlord
 slug: 2015-whats-new-in-electron
+tags: [release]
 ---
 
 There have been some interesting updates and talks given on Electron recently, here's a roundup.

--- a/blog/2020-season-of-docs.md
+++ b/blog/2020-season-of-docs.md
@@ -3,6 +3,7 @@ title: Google Season of Docs
 date: 2020-05-21T00:00:00.000Z
 authors: erickzhao
 slug: 2020-season-of-docs
+tags: [community]
 ---
 
 Electron is proud to be participating in the second edition of Google's Season of Docs initiative, which pairs mentors from open source organizations with technical writers to improve project documentation.

--- a/blog/2022-maintainer-summit.md
+++ b/blog/2022-maintainer-summit.md
@@ -3,6 +3,7 @@ title: Maintainer Summit 2022 Recap
 date: 2022-10-13T00:00:00.000Z
 authors: erickzhao
 slug: maintainer-summit-2022-recap
+tags: [news]
 ---
 
 # Maintainer Summit 2022 Recap

--- a/blog/2022-summer-of-code.md
+++ b/blog/2022-summer-of-code.md
@@ -7,6 +7,7 @@ authors:
   - dsanders11
   - VerteDinde
 slug: 2022-summer-of-code
+tags: [community]
 ---
 
 The Electron team is excited to announce that we will be participating in Google Summer of Code for the first time this year!

--- a/blog/2023-ecosystem-eoy-recap.md
+++ b/blog/2023-ecosystem-eoy-recap.md
@@ -3,6 +3,7 @@ title: Ecosystem 2023 Recap
 date: 2023-11-30T00:00:00.000Z
 authors: erickzhao
 slug: ecosystem-2023-eoy-recap
+tags: [ecosystem, showcase]
 ---
 
 Reflecting on the improvements and changes in Electron's developer ecosystem in 2023.

--- a/blog/2024-summer-of-code.md
+++ b/blog/2024-summer-of-code.md
@@ -6,6 +6,7 @@ authors:
   - VerteDinde
   - dsanders11
 slug: 2024-summer-of-code
+tags: [community]
 ---
 
 We are excited to announce that Electron has been accepted as a mentoring organization for

--- a/blog/8-week-cadence.md
+++ b/blog/8-week-cadence.md
@@ -3,6 +3,7 @@ title: New Electron Release Cadence
 date: 2021-07-14T00:00:00.000Z
 authors: VerteDinde
 slug: 8-week-cadence
+tags: [news, release]
 ---
 
 Beginning in September 2021, Electron will release a new major stable version every 8 weeks.

--- a/blog/accessibility-tools.md
+++ b/blog/accessibility-tools.md
@@ -3,6 +3,7 @@ title: Accessibility Tools
 date: 2016-08-23T00:00:00.000Z
 authors: jlord
 slug: accessibility-tools
+tags: [ecosystem]
 ---
 
 Making accessible applications is important and we're happy to introduce new functionality to [Devtron](https://electronjs.org/devtron) and [Spectron](https://electronjs.org/spectron) that gives developers the opportunity to make their apps better for everyone.

--- a/blog/api-docs-json-schema.md
+++ b/blog/api-docs-json-schema.md
@@ -3,6 +3,7 @@ title: Electron's API Docs as Structured Data
 date: 2016-09-27T00:00:00.000Z
 authors: zeke
 slug: api-docs-json-schema
+tags: [website]
 ---
 
 Today we're announcing some improvements to Electron's documentation. Every new

--- a/blog/app-feedback-program.md
+++ b/blog/app-feedback-program.md
@@ -3,6 +3,7 @@ title: Electron App Feedback Program
 date: 2018-10-02T00:00:00.000Z
 authors: sofianguy
 slug: app-feedback-program
+tags: [community]
 ---
 
 Electron is working on making its release cycles faster and more stable. To make that possible, we've started the App Feedback Program for large-scale Electron apps to test our beta releases and report app-specific issues to us. This helps us to prioritize work that will get applications upgraded to our next stable release sooner.

--- a/blog/apple-silicon.md
+++ b/blog/apple-silicon.md
@@ -3,6 +3,7 @@ title: Apple Silicon Support
 date: 2020-10-15T00:00:00.000Z
 authors: MarshallOfSound
 slug: apple-silicon
+tags: [features]
 ---
 
 With Apple Silicon hardware being released later this year, what does the path look like for you to get your Electron app running on the new hardware?

--- a/blog/august-2016-roundup.md
+++ b/blog/august-2016-roundup.md
@@ -3,6 +3,7 @@ title: 'August 2016: New Apps'
 date: 2016-09-06T00:00:00.000Z
 authors: jlord
 slug: august-2016-roundup
+tags: [community, showcase]
 ---
 
 Here are the new Electron apps that were added to the site in August.

--- a/blog/autoupdating-electron-apps.md
+++ b/blog/autoupdating-electron-apps.md
@@ -3,6 +3,7 @@ title: Easier AutoUpdating for Open-Source Apps
 date: 2018-05-01T00:00:00.000Z
 authors: zeke
 slug: autoupdating-electron-apps
+tags: [ecosystem]
 ---
 
 Today we're releasing a free, open-source, hosted

--- a/blog/beaker-browser.md
+++ b/blog/beaker-browser.md
@@ -7,6 +7,7 @@ authors:
     image_url: 'https://github.com/pfrazee.png?size=96'
   - zeke
 slug: beaker-browser
+tags: [community, showcase]
 ---
 
 This week we caught up with [Paul Frazee](http://pfrazee.github.io/), creator

--- a/blog/cadence-pause.md
+++ b/blog/cadence-pause.md
@@ -3,6 +3,7 @@ title: Upcoming Electron Releases
 date: 2020-03-19T00:00:00.000Z
 authors: codebytere
 slug: cadence-pause
+tags: [news]
 ---
 
 Electron is temporarily pausing major releases

--- a/blog/certificate-transparency-fix.md
+++ b/blog/certificate-transparency-fix.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/kevinsawicki'
   image_url: 'https://github.com/kevinsawicki.png?size=96'
 slug: certificate-transparency-fix
+tags: [news]
 ---
 
 Electron [1.4.12] contains an important patch that fixes an upstream Chrome

--- a/blog/dat.md
+++ b/blog/dat.md
@@ -13,6 +13,7 @@ authors:
     image_url: 'https://github.com/maxogden.png?size=96'
   - zeke
 slug: dat
+tags: [community, showcase]
 ---
 
 This week's featured project is [Dat](https://datproject.org/), a

--- a/blog/dec-quiet-month-21.md
+++ b/blog/dec-quiet-month-21.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/groundwater'
   image_url: 'https://github.com/groundwater.png?size=96'
 slug: a-quiet-place-21
+tags: [news]
 ---
 
 The Electron project will pause for the month of December 2021, then return to full speed in January 2022.

--- a/blog/dec-quiet-month-22.md
+++ b/blog/dec-quiet-month-22.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/PlaineKevin'
   image_url: 'https://github.com/plainekevin.png?size=96'
 slug: a-quiet-place-22
+tags: [news]
 ---
 
 The Electron project will pause for the month of December 2022, then return to full speed in January 2023.

--- a/blog/dec-quiet-period-23.md
+++ b/blog/dec-quiet-period-23.md
@@ -7,6 +7,7 @@ authors:
     image_url: 'https://github.com/PlaineKevin.png?size=96'
   - erickzhao
 slug: dec-quiet-period-23
+tags: [news]
 ---
 
 The Electron project will pause for the month of December 2023, then return to full speed in

--- a/blog/discord-hacktoberfest-2020.md
+++ b/blog/discord-hacktoberfest-2020.md
@@ -3,6 +3,7 @@ title: Community Discord Server and Hacktoberfest
 date: 2020-10-01T00:00:00.000Z
 authors: erickzhao
 slug: discord-hacktoberfest-2020
+tags: [community]
 ---
 
 Join us for community bonding and a month-long celebration of open-source.

--- a/blog/electron-api-changes.md
+++ b/blog/electron-api-changes.md
@@ -3,6 +3,7 @@ title: API Changes Coming in Electron 1.0
 date: 2015-11-17T00:00:00.000Z
 authors: zcbenz
 slug: electron-api-changes
+tags: [release]
 ---
 
 Since the beginning of Electron, starting way back when it used to be called Atom-Shell, we have been experimenting with providing a nice cross-platform JavaScript API for Chromium's content module and native GUI components. The APIs started very organically, and over time we have made several changes to improve the initial designs.

--- a/blog/electron-doumentation.md
+++ b/blog/electron-doumentation.md
@@ -3,6 +3,7 @@ title: Electron Documentation
 date: 2015-06-04T00:00:00.000Z
 authors: jlord
 slug: electron-doumentation
+tags: [website]
 ---
 
 This week we've given Electron's documentation a home on [electronjs.org](https://electronjs.org). You can visit [/docs/latest](https://electronjs.org/docs/latest) for the latest set of docs. We'll keep versions of older docs, too, so you're able to visit [/docs/vX.XX.X](https://electronjs.org/docs/v0.26.0) for the docs that correlate to the version you're using.

--- a/blog/electron-internals-building-chromium-as-a-library.md
+++ b/blog/electron-internals-building-chromium-as-a-library.md
@@ -3,6 +3,7 @@ title: 'Electron Internals: Building Chromium as a Library'
 date: 2017-03-03T00:00:00.000Z
 authors: zcbenz
 slug: electron-internals-building-chromium-as-a-library
+tags: [internals]
 ---
 
 Electron is based on Google's open-source Chromium, a project that is not

--- a/blog/electron-internals-node-integration.md
+++ b/blog/electron-internals-node-integration.md
@@ -3,6 +3,7 @@ title: 'Electron Internals: Message Loop Integration'
 date: 2016-07-28T00:00:00.000Z
 authors: zcbenz
 slug: electron-internals-node-integration
+tags: [internals]
 ---
 
 This is the first post of a series that explains the internals of Electron. This

--- a/blog/electron-internals-using-node-as-a-library.md
+++ b/blog/electron-internals-using-node-as-a-library.md
@@ -3,6 +3,7 @@ title: 'Electron Internals: Using Node as a Library'
 date: 2016-08-08T00:00:00.000Z
 authors: zcbenz
 slug: electron-internals-using-node-as-a-library
+tags: [internals]
 ---
 
 This is the second post in an ongoing series explaining the internals of

--- a/blog/electron-internals-weak-references.md
+++ b/blog/electron-internals-weak-references.md
@@ -3,6 +3,7 @@ title: 'Electron Internals: Weak References'
 date: 2016-09-20T00:00:00.000Z
 authors: zcbenz
 slug: electron-internals-weak-references
+tags: [internals]
 ---
 
 As a language with garbage collection, JavaScript frees users from managing

--- a/blog/electron-joins-openjsf.md
+++ b/blog/electron-joins-openjsf.md
@@ -3,6 +3,7 @@ title: Electron joins the OpenJS Foundation
 date: 2019-12-11T00:00:00.000Z
 authors: felixrieseberg
 slug: electron-joins-openjsf
+tags: [news]
 ---
 
 At [Node+JS Interactive](https://events19.linuxfoundation.org/events/nodejs-interactive-2019/) in Montreal, the [OpenJS Foundation](https://openjsf.org/) announced that it accepted Electron into the Foundation's incubation program. The Foundation is committed to supporting the healthy growth of the JavaScript ecosystem and web technologies by providing a neutral organization to host and sustain projects, as well as collaboratively fund activities for the benefit of the community at large.

--- a/blog/electron-meetup.md
+++ b/blog/electron-meetup.md
@@ -3,6 +3,7 @@ title: Electron Meetup at GitHub HQ
 date: 2015-09-17T00:00:00.000Z
 authors: jlord
 slug: electron-meetup
+tags: [community]
 ---
 
 Join us September 29th at GitHub's HQ for an Electron meetup hosted by Atom team members [@jlord](https://github.com/jlord) and [@kevinsawicki](https://github.com/kevinsawicki). There will be talks, food to snack on, and time to hangout and meet others doing cool things with Electron. We'll also have a bit of time to do lightning talks for those interested. Hope to see you there!

--- a/blog/electron-openjs-impact-project.md
+++ b/blog/electron-openjs-impact-project.md
@@ -3,6 +3,7 @@ title: Electron becomes an OpenJS Foundation Impact Project
 date: 2020-06-23T00:00:00.000Z
 authors: VerteDinde
 slug: electron-openjs-impact-project
+tags: [news]
 ---
 
 At [OpenJS World](https://events.linuxfoundation.org/openjs-world/) this morning, we announced that Electron has officially graduated from the [OpenJS Foundation's](https://openjsf.org/) incubation program, and is now an OpenJS Foundation Impact Project.

--- a/blog/electron-podcasts.md
+++ b/blog/electron-podcasts.md
@@ -3,6 +3,7 @@ title: Electron Podcasts
 date: 2016-07-26T00:00:00.000Z
 authors: jlord
 slug: electron-podcasts
+tags: [community]
 ---
 
 Looking for an introduction to Electron? Two new podcasts have just been released that give a great overview of what it is, why it was built, and how it is being used.

--- a/blog/electron-updates-mac-app-store-and-windows-auto-updater.md
+++ b/blog/electron-updates-mac-app-store-and-windows-auto-updater.md
@@ -3,6 +3,7 @@ title: Mac App Store and Windows Auto Updater on Electron
 date: 2015-11-05T00:00:00.000Z
 authors: jlord
 slug: electron-updates-mac-app-store-and-windows-auto-updater
+tags: [ecosystem]
 ---
 
 Recently Electron added two exciting features: a Mac App Store compatible build and a built-in Windows auto updater.

--- a/blog/electron.md
+++ b/blog/electron.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/kevinsawicki'
   image_url: 'https://github.com/kevinsawicki.png?size=96'
 slug: electron
+tags: [news]
 ---
 
 Atom Shell is now called Electron. You can learn more about Electron and what people are building with it at its new home [electronjs.org][electron].

--- a/blog/filereader-fix.md
+++ b/blog/filereader-fix.md
@@ -3,6 +3,7 @@ title: Chromium FileReader Vulnerability Fix
 date: 2019-03-07T00:00:00.000Z
 authors: MarshallOfSound
 slug: filereader-fix
+tags: [security]
 ---
 
 A High severity vulnerability has been discovered in Chrome which affects all software based on Chromium, including Electron.

--- a/blog/forge-v6-release.md
+++ b/blog/forge-v6-release.md
@@ -7,6 +7,7 @@ authors:
   - erickzhao
 slug: forge-v6-release
 toc_max_heading_level: 3
+tags: [ecosystem]
 ---
 
 import Tabs from '@theme/Tabs';

--- a/blog/from-native-to-js.md
+++ b/blog/from-native-to-js.md
@@ -3,6 +3,7 @@ title: From native to JavaScript in Electron
 date: 2019-03-19T00:00:00.000Z
 authors: codebytere
 slug: from-native-to-js
+tags: [internals]
 ---
 
 How do Electron's features written in C++ or Objective-C get to JavaScript so they're available to an end-user?

--- a/blog/ghost.md
+++ b/blog/ghost.md
@@ -5,6 +5,7 @@ authors:
   - felixrieseberg
   - zeke
 slug: ghost
+tags: [community, showcase]
 ---
 
 This week we chatted with [Felix Rieseberg](https://felixrieseberg.com/), desktop engineer at [Slack](https://slack.com/) and maintainer of [Ghost Desktop](https://ghost.org/downloads/), an Electron client for the [Ghost](https://ghost.org/) publishing platform.

--- a/blog/gn.md
+++ b/blog/gn.md
@@ -3,6 +3,7 @@ title: Using GN to Build Electron
 date: 2018-09-05T00:00:00.000Z
 authors: nornagon
 slug: gn
+tags: [news]
 ---
 
 Electron now uses GN to build itself. Here's a discussion of why.

--- a/blog/governance.md
+++ b/blog/governance.md
@@ -5,6 +5,7 @@ authors:
   - ckerr
   - sofianguy
 slug: governance
+tags: [news]
 ---
 
 As Electron grows in popularity for desktop applications, the team working on it has also grown: we have more fulltime maintainers who work for different companies, live in different timezones, and have different interests. We're introducing a governance structure so we can keep growing smoothly.

--- a/blog/i18n-updates.md
+++ b/blog/i18n-updates.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/vanessayuenn'
   image_url: 'https://github.com/vanessayuenn.png?size=96'
 slug: i18n-updates
+tags: [website]
 ---
 
 Ever since the [launch](https://electronjs.org/blog/new-website) of the new internationalized Electron website, we have been working hard to make the Electron development experience even more accessible to developers outside of the English speaking world.

--- a/blog/in-app-purchases.md
+++ b/blog/in-app-purchases.md
@@ -3,6 +3,7 @@ title: 'New in Electron 2: In-App Purchases'
 date: 2018-04-04T00:00:00.000Z
 authors: zeke
 slug: in-app-purchases
+tags: [features]
 ---
 
 The new Electron 2.0 release line is [packed](https://github.com/electron/electron/releases/tag/v2.0.0-beta.1) with new features and fixes. One of the highlights from this new major version is a new

--- a/blog/jasper.md
+++ b/blog/jasper.md
@@ -10,6 +10,7 @@ authors:
     image_url: 'https://github.com/watilde.png?size=96'
   - zeke
 slug: jasper
+tags: [community, showcase]
 ---
 
 This week we interviewed the creator of [Jasper], an Electron-based tool for

--- a/blog/july-2016-roundup.md
+++ b/blog/july-2016-roundup.md
@@ -3,6 +3,7 @@ title: 'July 2016: New Apps and Meetups'
 date: 2016-08-04T00:00:00.000Z
 authors: jlord
 slug: july-2016-roundup
+tags: [community, showcase]
 ---
 
 We're starting a monthly roundup to highlight activity in the Electron community. Each roundup will feature things like new apps, upcoming meetups, tools, videos, etc.

--- a/blog/kap.md
+++ b/blog/kap.md
@@ -10,6 +10,7 @@ authors:
     image_url: 'https://github.com/sindresorhus.png?size=96'
   - zeke
 slug: kap
+tags: [community, showcase]
 ---
 
 The Electron community is growing quickly, and people are creating powerful

--- a/blog/latest-v8-chromium-features.md
+++ b/blog/latest-v8-chromium-features.md
@@ -3,6 +3,7 @@ title: Use V8 and Chromium Features in Electron
 date: 2016-01-07T00:00:00.000Z
 authors: jlord
 slug: latest-v8-chromium-features
+tags: [features]
 ---
 
 Building an Electron application means you only need to create one codebase and design for one browser, which is pretty handy. But because Electron stays up to date with [Node.js](http://nodejs.org) and [Chromium](https://www.chromium.org) as they release, you also get to make use of the great features they ship with. In some cases this eliminates dependencies you might have previously needed to include in a web app.

--- a/blog/linux-32bit-support.md
+++ b/blog/linux-32bit-support.md
@@ -3,6 +3,7 @@ title: Discontinuing support for 32-bit Linux
 date: 2019-03-04T00:00:00.000Z
 authors: felixrieseberg
 slug: linux-32bit-support
+tags: [news]
 ---
 
 The Electron team will discontinue support for 32-bit Linux (ia32 / i386) starting with Electron v4.0. The last version of Electron that supports 32-bit based installations of Linux is Electron v3.1, which will receive support releases until Electron v6 is released. Support for 64-bit based Linux and `armv7l` will continue unchanged.

--- a/blog/new-website.md
+++ b/blog/new-website.md
@@ -3,6 +3,7 @@ title: Electron's New Internationalized Website
 date: 2017-11-13T00:00:00.000Z
 authors: zeke
 slug: new-website
+tags: [website]
 ---
 
 Electron has a new website at [electronjs.org]! We've replaced

--- a/blog/nodejs-native-addons-and-electron-5.md
+++ b/blog/nodejs-native-addons-and-electron-5.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/BinaryMuse'
   image_url: 'https://github.com/BinaryMuse.png?size=96'
 slug: nodejs-native-addons-and-electron-5
+tags: [release, news]
 ---
 
 If you're having trouble using a native Node.js addon with Electron 5.0, there's a chance it needs to be updated to work with the most recent version of V8.

--- a/blog/npm-install-electron.md
+++ b/blog/npm-install-electron.md
@@ -3,6 +3,7 @@ title: npm install electron
 date: 2016-08-16T00:00:00.000Z
 authors: zeke
 slug: npm-install-electron
+tags: [news]
 ---
 
 As of Electron version 1.3.1, you can `npm install electron --save-dev` to

--- a/blog/rfcs.md
+++ b/blog/rfcs.md
@@ -3,6 +3,7 @@ title: Introducing electron/rfcs
 date: 2024-02-13T12:00:00.000Z
 authors: erickzhao
 slug: rfcs
+tags: [community, features]
 ---
 
 Electron’s [API Working Group](https://github.com/electron/governance/tree/main/wg-api) is

--- a/blog/s3-bucket-change.md
+++ b/blog/s3-bucket-change.md
@@ -2,6 +2,7 @@
 title: 'S3 Bucket Migration'
 date: 2022-05-06T00:00:00.000Z
 authors: MarshallOfSound
+tags: [news]
 ---
 
 Electron is changing its primary S3 bucket, you may need to update your build scripts

--- a/blog/search.md
+++ b/blog/search.md
@@ -10,6 +10,7 @@ authors:
     image_url: 'https://github.com/vanessayuenn.png?size=96'
   - zeke
 slug: search
+tags: [website]
 ---
 
 The Electron website has a new search engine that delivers instant results for

--- a/blog/september-2016-roundup.md
+++ b/blog/september-2016-roundup.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/haacked'
   image_url: 'https://github.com/haacked.png?size=96'
 slug: september-2016-roundup
+tags: [community]
 ---
 
 Here are the new Electron apps and talks that were added to the site in September.

--- a/blog/simple-samples.md
+++ b/blog/simple-samples.md
@@ -3,6 +3,7 @@ title: Electron Simple Samples
 date: 2017-01-19T00:00:00.000Z
 authors: zeke
 slug: simple-samples
+tags: [community]
 ---
 
 We recently hosted an Electron hackathon at GitHub HQ for members of [Hackbright Academy](https://hackbrightacademy.com), a coding school for women founded in San Francisco. To help attendees get a head start on their projects, our own [Kevin Sawicki](https://github.com/kevinsawicki) created a few sample Electron applications.

--- a/blog/spectron-deprecation-notice.md
+++ b/blog/spectron-deprecation-notice.md
@@ -3,6 +3,7 @@ title: Spectron Deprecation Notice
 date: 2021-12-01T00:00:00.000Z
 authors: VerteDinde
 slug: spectron-deprecation-notice
+tags: [ecosystem]
 ---
 
 Spectron will be deprecated on February 1st, 2022.

--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -1,4 +1,29 @@
+community:
+  label: 'Community'
+  description: 'Community initiatives in Electron'
+ecosystem:
+  label: 'Ecosystem'
+  description: >
+    'Blog posts about Electron's package ecosystem'
+features:
+  label: 'Features'
+  description: 'Showcasing new features in Electron core'
+internals:
+  label: 'Electron Internals'
+  description: >
+    'Technical deep dives through Electron's source code'
+news:
+  label: 'Project News'
+  description: 'Important announcements about the Electron project'
 release:
+  label: 'Release'
   description: 'Blog posts about new Electron releases'
 security:
+  label: 'Security'
   description: 'Blog posts related to security'
+showcase:
+  label: 'Showcase'
+  description: 'Highlighting featured Electron use cases'
+website:
+  label: 'Website'
+  description: 'Updates on the electronjs.org website and docs'

--- a/blog/touch-bar-support.md
+++ b/blog/touch-bar-support.md
@@ -6,6 +6,7 @@ authors:
   url: 'https://github.com/kevinsawicki'
   image_url: 'https://github.com/kevinsawicki.png?size=96'
 slug: touch-bar-support
+tags: [features]
 ---
 
 The Electron [1.6.3] beta release contains initial support for the macOS [Touch Bar].

--- a/blog/typescript.md
+++ b/blog/typescript.md
@@ -3,6 +3,7 @@ title: Announcing TypeScript support in Electron
 date: 2017-06-01T00:00:00.000Z
 authors: zeke
 slug: typescript
+tags: [ecosystem]
 ---
 
 The `electron` npm package now includes a TypeScript definition file that provides detailed annotations of the entire Electron API. These annotations can improve your Electron development

--- a/blog/userland.md
+++ b/blog/userland.md
@@ -3,6 +3,7 @@ title: Electron Userland
 date: 2016-12-20T00:00:00.000Z
 authors: zeke
 slug: userland
+tags: [community, ecosystem]
 ---
 
 We've added a new [userland](https://electronjs.org/userland) section to

--- a/blog/v8-memory-cage.md
+++ b/blog/v8-memory-cage.md
@@ -3,6 +3,7 @@ title: Electron and the V8 Memory Cage
 date: 2022-06-30T00:00:00.000Z
 authors: nornagon
 slug: v8-memory-cage
+tags: [news]
 ---
 
 Electron 21 and later will have the V8 Memory Cage enabled, with implications for some native modules.

--- a/blog/voltra.md
+++ b/blog/voltra.md
@@ -10,6 +10,7 @@ authors:
     image_url: 'https://github.com/aprileelcich.png?size=96'
   - zeke
 slug: voltra
+tags: [community, showcase]
 ---
 
 This week we met with [Aprile Elcich](https://twitter.com/aprileelcich) and

--- a/blog/webtorrent.md
+++ b/blog/webtorrent.md
@@ -7,6 +7,7 @@ authors:
     image_url: 'https://github.com/feross.png?size=96'
   - zeke
 slug: webtorrent
+tags: [community, showcase]
 ---
 
 This week we caught up with [@feross](https://github.com/feross) and [@dcposch](https://github.com/dcposch) to talk about WebTorrent, the web-powered torrent client that connects users together to form a distributed, decentralized browser-to-browser network.

--- a/blog/webview2.md
+++ b/blog/webview2.md
@@ -6,6 +6,7 @@ authors:
     url: 'https://github.com/electron'
     image_url: 'https://github.com/electron.png?size=96'
 slug: webview2
+tags: [internals]
 ---
 
 Over the past weeks, we’ve received several questions about the differences between the new [WebView2](https://docs.microsoft.com/en-us/microsoft-edge/webview2/) and Electron.

--- a/blog/windows-7-deprecation.md
+++ b/blog/windows-7-deprecation.md
@@ -3,6 +3,7 @@ title: Farewell, Windows 7/8/8.1
 date: 2022-11-29T00:00:00.000Z
 authors: VerteDinde
 slug: windows-7-to-8-1-deprecation-notice
+tags: [news]
 ---
 
 Electron will end support of Windows 7, Windows 8 and Windows 8.1 beginning in Electron 23.

--- a/blog/wordpress.md
+++ b/blog/wordpress.md
@@ -10,6 +10,7 @@ authors:
     image_url: 'https://github.com/johngodley.png?size=96'
   - zeke
 slug: wordpress
+tags: [community, showcase]
 ---
 
 This week we caught up with folks at [Automattic](https://automattic.com/) to


### PR DESCRIPTION
Ignore all the broken links from the past decade. A little more expansive use of our tags! See `blog/tags.yml` for new categories.