### PR TITLE
ci: bump dsanders11/github-app-commit-action from v1.4.0 to v1.4.1

### DIFF
--- a/.github/workflows/update-docs-branch.yml
+++ b/.github/workflows/update-docs-branch.yml
@@ -42,7 +42,7 @@ jobs:
           yarn pre-build ${{ github.event.client_payload.sha || github.event.inputs.sha }}
           git add .
       - name: Push changes
-        uses: dsanders11/github-app-commit-action@48d2ff8c1a855eb15d16afa97ae12616456d7cbc # v1.4.0
+        uses: dsanders11/github-app-commit-action@5c7daabae956f8143277417996b26a173439e1b7 # v1.4.1
         with:
           message: 'chore: update ref to docs (🤖)'
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -39,7 +39,7 @@ jobs:
           yarn pre-build ${{ github.event.client_payload.sha || github.event.inputs.sha }} ${{ github.event.client_payload.branch || github.event.inputs.branch }}
           git add .
       - name: Push changes
-        uses: dsanders11/github-app-commit-action@48d2ff8c1a855eb15d16afa97ae12616456d7cbc # v1.4.0
+        uses: dsanders11/github-app-commit-action@5c7daabae956f8143277417996b26a173439e1b7 # v1.4.1
         with:
           message: 'chore: update ref to docs (🤖)'
           token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Will fix an issue which corrupts images on commit, I think it's bit us once on `gatekeeper.png` in the past.