### PR TITLE
style: default font sizes for docs

### DIFF
--- a/src/pages/home/_index.module.scss
+++ b/src/pages/home/_index.module.scss
@@ -1,8 +1,3 @@
-p {
-  line-height: 1.5;
-  font-size: 1.1rem;
-}
-
 summary {
   font-weight: bold;
 }
@@ -24,6 +19,11 @@ summary {
   h3 {
     font-size: 1.6em;
     font-weight: 700;
+  }
+
+  p {
+    line-height: 1.5;
+    font-size: 1.1rem;
   }
 
   @media (max-width: 1000px) {


### PR DESCRIPTION
Noticed that we had some stray styles in our docs that made certain text sizes larger than others. This PR fixes that.

<img width="816" alt="image" src="https://github.com/user-attachments/assets/dd3af62c-c3e4-4239-b1b8-96a194ef177e">
