### PR TITLE
ci: try fixing publish job

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -29,6 +29,8 @@ jobs:
 
   build-and-deploy:
     uses: electron/website/.github/workflows/build-and-deploy.yml@main
+    permissions:
+      actions: read
     with:
       branch: main
     secrets:


### PR DESCRIPTION
Hit an issue with nested workflows and permissions. I think this should fix it.

> [The workflow is not valid. .github/workflows/push-main.yml (Line: 30, Col: 3): Error calling workflow 'electron/website/.github/workflows/build-and-deploy.yml@main'. The nested job 'build_and_deploy' is requesting 'actions: read', but is only allowed 'actions: none'.](https://github.com/electron/website/actions/runs/10356949205)