### PR TITLE
docs: Electron 32 blog

### DIFF
--- a/blog/electron-32-0.md
+++ b/blog/electron-32-0.md
@@ -21,7 +21,7 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 - Added new API version history in our documentation, a feature created by @piotrpdev as part of Google Summer of Code. [#42982](https://github.com/electron/electron/pull/42982)
 - Removed nonstandard File.path extension from the Web File API. [#42053](https://github.com/electron/electron/pull/42053)
 - Aligned failure pathway in Web [File System API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API) with upstream when attempting to open a file or directory in a blocked path. [#42993](https://github.com/electron/electron/pull/42993)
-- Added the following existing navigation-related APIs to `webcontents.navigationHistory`: `canGoBack`, `goBack`, `canGoForward`, `goForward`, `canGoToOffset`, `goToOffset`, `clear`. The previous navigation APIs are not deprecated. [#41752](https://github.com/electron/electron/pull/41752)
+- Added the following existing navigation-related APIs to `webcontents.navigationHistory`: `canGoBack`, `goBack`, `canGoForward`, `goForward`, `canGoToOffset`, `goToOffset`, `clear`. The previous navigation APIs are now deprecated. [#41752](https://github.com/electron/electron/pull/41752)
 
 ### Stack Changes
 
@@ -43,7 +43,7 @@ Electron 32 upgrades Chromium from `126.0.6478.36` to `128.0.6613.36`, Node from
 - Added a new property `prefersReducedTransparency` to `nativeTheme`, which indicates whether the user has chosen to reduce OS-level transparency via system accessibility settings. [#43137](https://github.com/electron/electron/pull/43137)
 - Aligned failure pathway in File System Access API with upstream when attempting to open a file or directory in a blocked path. [#42993](https://github.com/electron/electron/pull/42993)
 - Enabled the Windows Control Overlay API on Linux. [#42681](https://github.com/electron/electron/pull/42681)
-- Enabled `zstd` compression in net http requests. [#43300](https://github.com/electron/electron/pull/43300)
+- Enabled `zstd` compression in network requests. [#43300](https://github.com/electron/electron/pull/43300)
 
 ### Breaking Changes
 

--- a/blog/electron-32-0.md
+++ b/blog/electron-32-0.md
@@ -1,0 +1,119 @@
+---
+title: Electron 32.0.0
+date: 2024-08-20T00:00:00.000Z
+authors: VerteDinde
+slug: electron-32-0
+tags: [release]
+---
+
+Electron 32.0.0 has been released! It includes upgrades to Chromium `128.0.6613.36`, V8 `12.8`, and Node `20.16.0`.
+
+---
+
+The Electron team is excited to announce the release of Electron 32.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://releases.electronjs.org/releases/stable). Continue reading for details about this release.
+
+If you have any feedback, please share it with us on [Twitter](https://twitter.com/electronjs) or [Mastodon](https://social.lfx.dev/@electronjs), or join our community [Discord](https://discord.com/invite/electronjs)! Bugs and feature requests can be reported in Electron's [issue tracker](https://github.com/electron/electron/issues).
+
+## Notable Changes
+
+### Highlights
+
+- Added new API version history in our documentation, a feature created by @piotrpdev as part of Google Summer of Code. [#42982](https://github.com/electron/electron/pull/42982)
+- Removed nonstandard File.path extension from the Web File API. [#42053](https://github.com/electron/electron/pull/42053)
+- Aligned failure pathway in File System Access API with upstream when attempting to open a file or directory in a blocked path. [#42993](https://github.com/electron/electron/pull/42993)
+- Added the following existing navigation related APIs to `webcontents.navigationHistory`: `canGoBack`, `goBack`, `canGoForward`, `goForward`, `canGoToOffset`, `goToOffset`, `clear`. The previous navigation APIs are not deprecated. [#41752](https://github.com/electron/electron/pull/41752)
+
+### Stack Changes
+
+- Chromium`128.0.6613.36`
+  - [New in 128](https://developer.chrome.com/blog/new-in-chrome-128/)
+  - [New in 127](https://developer.chrome.com/blog/new-in-chrome-127/)
+- Node `20.16.0`
+  - [Node 20.16.0 blog post](https://nodejs.org/en/blog/release/v20.16.0/)
+- V8 `12.8`
+
+Electron 32 upgrades Chromium from `126.0.6478.36` to `128.0.6613.36`, Node from `20.14.0` to `20.16.0`, and V8 from `12.6` to `12.8`.
+
+### New Features
+
+- Added support for responding to auth requests initiated from utility process. [#43317](https://github.com/electron/electron/pull/43317)
+- Added `cumulativeCPUUsage` to `AppMetrics` and `CPUUsage`. [#41819](https://github.com/electron/electron/pull/41819)
+- Added the following existing navigation related APIs to `webcontents.navigationHistory`: `canGoBack`, `goBack`, `canGoForward`, `goForward`, `canGoToOffset`, `goToOffset`, `clear`. [#41752](https://github.com/electron/electron/pull/41752)
+- Extended `WebContentsView` to accept pre-existing `webContents` object. [#42086](https://github.com/electron/electron/pull/42086)
+- Added a new property `prefersReducedTransparency` to `nativeTheme`, which indicates whether the user has chosen to reduce OS-level transparency via system accessibility settings. [#43137](https://github.com/electron/electron/pull/43137)
+- Aligned failure pathway in File System Access API with upstream when attempting to open a file or directory in a blocked path. [#42993](https://github.com/electron/electron/pull/42993)
+- Enabled the Windows Control Overlay API on Linux. [#42681](https://github.com/electron/electron/pull/42681)
+- Enabled `zstd` compression in net http requests. [#43300](https://github.com/electron/electron/pull/43300)
+
+### Breaking Changes
+
+#### Removed: `File.path`
+
+The nonstandard `path` property of the Web `File` object was added in an early version of Electron as a convenience method for working with native files when doing everything in the renderer was more common. However, it represents a deviation from the standard and poses a minor security risk as well, so beginning in Electron 32.0 it has been removed in favor of the [`webUtils.getPathForFile`](api/web-utils.md#webutilsgetpathforfilefile) method.
+
+```js
+// Before (renderer)
+const file = document.querySelector('input[type=file]');
+alert(`Uploaded file path was: ${file.path}`);
+```
+
+```js
+// After (renderer)
+const file = document.querySelector('input[type=file]');
+electron.showFilePath(file);
+
+// After (preload)
+const { contextBridge, webUtils } = require('electron');
+
+contextBridge.exposeInMainWorld('electron', {
+  showFilePath(file) {
+    // It's best not to expose the full file path to the web content if
+    // possible.
+    const path = webUtils.getPathForFile(file);
+    alert(`Uploaded file path was: ${path}`);
+  },
+});
+```
+
+#### Deprecated: `clearHistory`, `canGoBack`, `goBack`, `canGoForward`, `goForward`, `goToIndex`, `canGoToOffset`, `goToOffset` on `WebContents`
+
+The navigation-related APIs are now deprecated. These APIs have been moved to the `navigationHistory` property of `WebContents` to provide a more structured and intuitive interface for managing navigation history.
+
+```js
+// Deprecated
+win.webContents.clearHistory();
+win.webContents.canGoBack();
+win.webContents.goBack();
+win.webContents.canGoForward();
+win.webContents.goForward();
+win.webContents.goToIndex(index);
+win.webContents.canGoToOffset();
+win.webContents.goToOffset(index);
+
+// Replace with
+win.webContents.navigationHistory.clear();
+win.webContents.navigationHistory.canGoBack();
+win.webContents.navigationHistory.goBack();
+win.webContents.navigationHistory.canGoForward();
+win.webContents.navigationHistory.goForward();
+win.webContents.navigationHistory.canGoToOffset();
+win.webContents.navigationHistory.goToOffset(index);
+```
+
+## End of Support for 29.x.y
+
+Electron 29.x.y has reached end-of-support as per the project's [support policy](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#version-support-policy). Developers and applications are encouraged to upgrade to a newer version of Electron.
+
+| E32 (Aug'24) | E33 (Oct'24) | E34 (Jan'25) |
+| ------------ | ------------ | ------------ |
+| 32.x.y       | 33.x.y       | 34.x.y       |
+| 31.x.y       | 32.x.y       | 33.x.y       |
+| 30.x.y       | 31.x.y       | 32.x.y       |
+
+## What's Next
+
+In the short term, you can expect the team to continue to focus on keeping up with the development of the major components that make up Electron, including Chromium, Node, and V8.
+
+You can find [Electron's public timeline here](https://www.electronjs.org/docs/latest/tutorial/electron-timelines).
+
+More information about future changes can be found on the [Planned Breaking Changes](https://github.com/electron/electron/blob/main/docs/breaking-changes.md) page.

--- a/blog/electron-32-0.md
+++ b/blog/electron-32-0.md
@@ -20,8 +20,8 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 
 - Added new API version history in our documentation, a feature created by @piotrpdev as part of Google Summer of Code. [#42982](https://github.com/electron/electron/pull/42982)
 - Removed nonstandard File.path extension from the Web File API. [#42053](https://github.com/electron/electron/pull/42053)
-- Aligned failure pathway in File System Access API with upstream when attempting to open a file or directory in a blocked path. [#42993](https://github.com/electron/electron/pull/42993)
-- Added the following existing navigation related APIs to `webcontents.navigationHistory`: `canGoBack`, `goBack`, `canGoForward`, `goForward`, `canGoToOffset`, `goToOffset`, `clear`. The previous navigation APIs are not deprecated. [#41752](https://github.com/electron/electron/pull/41752)
+- Aligned failure pathway in Web [File System API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API) with upstream when attempting to open a file or directory in a blocked path. [#42993](https://github.com/electron/electron/pull/42993)
+- Added the following existing navigation-related APIs to `webcontents.navigationHistory`: `canGoBack`, `goBack`, `canGoForward`, `goForward`, `canGoToOffset`, `goToOffset`, `clear`. The previous navigation APIs are not deprecated. [#41752](https://github.com/electron/electron/pull/41752)
 
 ### Stack Changes
 
@@ -36,10 +36,10 @@ Electron 32 upgrades Chromium from `126.0.6478.36` to `128.0.6613.36`, Node from
 
 ### New Features
 
-- Added support for responding to auth requests initiated from utility process. [#43317](https://github.com/electron/electron/pull/43317)
-- Added `cumulativeCPUUsage` to `AppMetrics` and `CPUUsage`. [#41819](https://github.com/electron/electron/pull/41819)
-- Added the following existing navigation related APIs to `webcontents.navigationHistory`: `canGoBack`, `goBack`, `canGoForward`, `goForward`, `canGoToOffset`, `goToOffset`, `clear`. [#41752](https://github.com/electron/electron/pull/41752)
-- Extended `WebContentsView` to accept pre-existing `webContents` object. [#42086](https://github.com/electron/electron/pull/42086)
+- Added support for responding to auth requests initiated from the utility process via the `app` module's [`'login'`](https://www.electronjs.org/docs/latest/api/app) event. [#43317](https://github.com/electron/electron/pull/43317)
+- Added the `cumulativeCPUUsage` property to the `CPUUsage` structure, which returns the total seconds of CPU time used since process startup. [#41819](https://github.com/electron/electron/pull/41819)
+- Added the following existing navigation related APIs to `webContents.navigationHistory`: `canGoBack`, `goBack`, `canGoForward`, `goForward`, `canGoToOffset`, `goToOffset`, `clear`. [#41752](https://github.com/electron/electron/pull/41752)
+- Extended `WebContentsView` to accept pre-existing `webContents` objects. [#42086](https://github.com/electron/electron/pull/42086)
 - Added a new property `prefersReducedTransparency` to `nativeTheme`, which indicates whether the user has chosen to reduce OS-level transparency via system accessibility settings. [#43137](https://github.com/electron/electron/pull/43137)
 - Aligned failure pathway in File System Access API with upstream when attempting to open a file or directory in a blocked path. [#42993](https://github.com/electron/electron/pull/42993)
 - Enabled the Windows Control Overlay API on Linux. [#42681](https://github.com/electron/electron/pull/42681)
@@ -49,7 +49,7 @@ Electron 32 upgrades Chromium from `126.0.6478.36` to `128.0.6613.36`, Node from
 
 #### Removed: `File.path`
 
-The nonstandard `path` property of the Web `File` object was added in an early version of Electron as a convenience method for working with native files when doing everything in the renderer was more common. However, it represents a deviation from the standard and poses a minor security risk as well, so beginning in Electron 32.0 it has been removed in favor of the [`webUtils.getPathForFile`](https://github.com/electron/electron/tree/main/docs/api/web-utils.md#webutilsgetpathforfilefile) method.
+The nonstandard `path` property of the Web [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) object was added in an early version of Electron as a convenience method for working with native files when doing everything in the renderer was more common. However, it represents a deviation from the standard and poses a minor security risk as well, so beginning in Electron 32.0 it has been removed in favor of the [`webUtils.getPathForFile`](https://github.com/electron/electron/tree/main/docs/api/web-utils.md#webutilsgetpathforfilefile) method.
 
 ```js
 // Before (renderer)
@@ -77,7 +77,7 @@ contextBridge.exposeInMainWorld('electron', {
 
 #### Deprecated: `clearHistory`, `canGoBack`, `goBack`, `canGoForward`, `goForward`, `goToIndex`, `canGoToOffset`, `goToOffset` on `WebContents`
 
-The navigation-related APIs are now deprecated. These APIs have been moved to the `navigationHistory` property of `WebContents` to provide a more structured and intuitive interface for managing navigation history.
+Navigation-related APIs on `WebContents` instances are now deprecated. These APIs have been moved to the `navigationHistory` property of `WebContents` to provide a more structured and intuitive interface for managing navigation history.
 
 ```js
 // Deprecated

--- a/blog/electron-32-0.md
+++ b/blog/electron-32-0.md
@@ -49,7 +49,7 @@ Electron 32 upgrades Chromium from `126.0.6478.36` to `128.0.6613.36`, Node from
 
 #### Removed: `File.path`
 
-The nonstandard `path` property of the Web `File` object was added in an early version of Electron as a convenience method for working with native files when doing everything in the renderer was more common. However, it represents a deviation from the standard and poses a minor security risk as well, so beginning in Electron 32.0 it has been removed in favor of the [`webUtils.getPathForFile`](api/web-utils.md#webutilsgetpathforfilefile) method.
+The nonstandard `path` property of the Web `File` object was added in an early version of Electron as a convenience method for working with native files when doing everything in the renderer was more common. However, it represents a deviation from the standard and poses a minor security risk as well, so beginning in Electron 32.0 it has been removed in favor of the [`webUtils.getPathForFile`](https://github.com/electron/electron/tree/main/docs/api/web-utils.md#webutilsgetpathforfilefile) method.
 
 ```js
 // Before (renderer)


### PR DESCRIPTION
This PR adds a new blog post for Electron 32. @electron/wg-releases, @electron/wg-outreach

Merge target: August 20th, after 32.0.0 releases.

⚠️ Do not merge until the following are completed ⚠️ 

* [x]   Update node, v8 and chromium versions from final chrome roll under Stack Changes section
* [x]   Edit link for M128 "New In Chrome" blog post
* [x]   Add a few bullets for New Features section
* [x]   Add any missing items in Breaking Changes section
* [x]   Update End of Support
* [x]   ~Update section with GSoC API history blog post, if we decide to publish that one first~ We'll edit the post after publish

_Note: The "Check Blog links" job is going to fail until the Chrome 128 announcement blog comes out. A fail is expected until about Tuesday_