### PR TITLE
fix(api-structure-previews): check arr length

### DIFF
--- a/src/transformers/api-structure-previews.ts
+++ b/src/transformers/api-structure-previews.ts
@@ -57,7 +57,10 @@ async function transformer(tree: Parent, file: VFile) {
     }
 
     // Temporarily remove this node, toMarkdown chokes on it
-    if (tree.children[tree.children.length - 1].type === 'mdxjsEsm') {
+    if (
+      tree.children.length > 0 &&
+      tree.children[tree.children.length - 1].type === 'mdxjsEsm'
+    ) {
       exportsNode = tree.children.pop();
     }
 


### PR DESCRIPTION
i18n builds sometimes fail with an opaque MDX compilation error. Locally, I am unable to reproduce the error when commenting out the API structure previews.

```
2024-08-28T18:10:44.3503233Z Error: MDX compilation failed for file "/home/runner/work/website/website/i18n/zh/docusaurus-plugin-content-docs/current/latest/api/native-image.md"
2024-08-28T18:10:44.3505973Z Cause: Cannot read properties of undefined (reading 'type')
```