### PR TITLE
ci: add `workflow_dispatch` to cron jobs

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency: publish
 

--- a/.github/workflows/update-i18n-deploy.yml
+++ b/.github/workflows/update-i18n-deploy.yml
@@ -3,6 +3,7 @@ name: 'Update i18n deploy'
 on:
   schedule:
     - cron: '0 0,12 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds the ability to manually trigger jobs that we normally run via cron.