### PR TITLE
fix(api-history): summary word wrap

### DIFF
--- a/src/components/ApiHistoryTable.module.scss
+++ b/src/components/ApiHistoryTable.module.scss
@@ -8,6 +8,8 @@
     font-weight: normal;
     font-style: italic;
 
+    word-wrap: normal;
+
     &:hover {
       cursor: pointer;
     }


### PR DESCRIPTION
Fixes a bug where the "History" summary wraps words unnecessarily. Only occurs on mobile devices for some reason.

| Before | After |
|:-------:|:------:|
| <img width="200" src="https://github.com/user-attachments/assets/36389956-c76c-45f4-bca7-d2d39555a453" /> | <img width="200" src="https://github.com/user-attachments/assets/f7e0f506-e540-45cc-b3a4-b81829f0d1e5" /> |