### PR TITLE
feat: add navigation-history to examples sections on sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -63,6 +63,7 @@ module.exports = {
         },
         'latest/tutorial/multithreading',
         'latest/tutorial/native-file-drag-drop',
+        'latest/tutorial/navigation-history',
         'latest/tutorial/notifications',
         'latest/tutorial/offscreen-rendering',
         'latest/tutorial/online-offline-events',


### PR DESCRIPTION
This PR:
- [x] Adds `latest/tutorial/navigation-history` to sidebar since https://github.com/electron/electron/pull/42980 has merged

