### PR TITLE
docs: add blog post for Electron 33.0.0 release

### DIFF
--- a/blog/electron-33-0.md
+++ b/blog/electron-33-0.md
@@ -35,14 +35,10 @@ Electron 33 upgrades Chromium from `128.0.6613.36` to `130.0.6723.44`, Node from
 
 ### New Features
 
-* Added the event `client-certificate-request-password` to app. It is dispatched when a PIN is needed to unlock a cryptographic device. [#41205](https://github.com/electron/electron/pull/41205) 
-* Added error event in utility process to support diagnostic reports on V8 fatal errors. [#43997](https://github.com/electron/electron/pull/43997) 
-* Added `View.setBorderRadius(radius)` for customizing the border radius of views—with compatibility for `WebContentsView`. [#42320](https://github.com/electron/electron/pull/42320) 
-* Added Linux support for the Windows Control Overlay API. [#41769](https://github.com/electron/electron/pull/41769) <span style="font-size:small;">(Also in [30](https://github.com/electron/electron/pull/42683), [31](https://github.com/electron/electron/pull/42682), [32](https://github.com/electron/electron/pull/42681))</span>
-* Added support for the macOS system picker in `desktopCapturer` and `setDisplayMediaRequestHandler`. [#43680](https://github.com/electron/electron/pull/43680) <span style="font-size:small;">(Also in [32](https://github.com/electron/electron/pull/43679))</span>
-* Added `DownloadItem.getCurrentBytesPerSecond()`, `DownloadItem.getPercentComplete()`, `DownloadItem.getEndTime()`. [#42805](https://github.com/electron/electron/pull/42805) <span style="font-size:small;">(Also in [30](https://github.com/electron/electron/pull/42914), [31](https://github.com/electron/electron/pull/42915), [32](https://github.com/electron/electron/pull/42913))</span>
-* Added a new property `prefersReducedTransparency` to `nativeTheme`, which indicates whether the user has chosen to reduce OS-level transparency via system accessibility settings. [#42862](https://github.com/electron/electron/pull/42862) <span style="font-size:small;">(Also in [30](https://github.com/electron/electron/pull/43138), [31](https://github.com/electron/electron/pull/43137), [32](https://github.com/electron/electron/pull/43024))</span>
-* Added support for responding to auth requests initiated from utility process via `app#login` event. [#42631](https://github.com/electron/electron/pull/42631) <span style="font-size:small;">(Also in [32](https://github.com/electron/electron/pull/43317))</span>
+* Added the event `client-certificate-request-password` to app. It is dispatched when a PIN is needed to unlock a cryptographic device. [#41205](https://github.com/electron/electron/pull/41205)
+* Added error event in utility process to support diagnostic reports on V8 fatal errors. [#43997](https://github.com/electron/electron/pull/43997)
+* Added `View.setBorderRadius(radius)` for customizing the border radius of views—with compatibility for `WebContentsView`. [#42320](https://github.com/electron/electron/pull/42320)
+* Extended `navigationHistory` API with 2 new functions for better history management. [#42014](https://github.com/electron/electron/pull/42014)
 
 ### Breaking Changes
 

--- a/blog/electron-33-0.md
+++ b/blog/electron-33-0.md
@@ -19,7 +19,9 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 
 ### Highlights
 
-FIXME
+- Added an event to help unlock cryptographic devices when a PIN is needed. [#41205](https://github.com/electron/electron/pull/41205) 
+- Extended `navigationHistory` API with 2 new functions for better history management. [#42014](https://github.com/electron/electron/pull/42014)
+- Improved native theme transparency checking. [#42862](https://github.com/electron/electron/pull/42862)
 
 ### Stack Changes
 
@@ -41,6 +43,13 @@ Electron 33 upgrades Chromium from `128.0.6613.36` to `130.0.6723.44`, Node from
 * Extended `navigationHistory` API with 2 new functions for better history management. [#42014](https://github.com/electron/electron/pull/42014)
 
 ### Breaking Changes
+
+#### Removed: macOS 10.15 support
+
+macOS 10.15 (Catalina) is no longer supported by [Chromium](https://chromium-review.googlesource.com/c/chromium/src/+/5734361).
+
+Older versions of Electron will continue to run on Catalina, but macOS 11 (Big Sur)
+or later will be required to run Electron v33.0.0 and higher.
 
 #### Behavior Changed: custom protocol URL handling on Windows
 
@@ -78,13 +87,6 @@ created with `respondToAuthRequestsFromMainProcess` option.
 #### Deprecated: `textured` option in `BrowserWindowConstructorOption.type`
 
 The `textured` option of `type` in `BrowserWindowConstructorOptions` has been deprecated with no replacement. This option relied on the [`NSWindowStyleMaskTexturedBackground`](https://developer.apple.com/documentation/appkit/nswindowstylemask/nswindowstylemasktexturedbackground) style mask on macOS, which has been deprecated with no alternative.
-
-#### Removed: macOS 10.15 support
-
-macOS 10.15 (Catalina) is no longer supported by [Chromium](https://chromium-review.googlesource.com/c/chromium/src/+/5734361).
-
-Older versions of Electron will continue to run on Catalina, but macOS 11 (Big Sur)
-or later will be required to run Electron v33.0.0 and higher.
 
 #### Deprecated: `systemPreferences.accessibilityDisplayShouldReduceTransparency`
 

--- a/blog/electron-33-0.md
+++ b/blog/electron-33-0.md
@@ -14,12 +14,11 @@ The Electron team is excited to announce the release of Electron 33.0.0! You can
 
 If you have any feedback, please share it with us on [Twitter](https://twitter.com/electronjs) or [Mastodon](https://social.lfx.dev/@electronjs), or join our community [Discord](https://discord.com/invite/electronjs)! Bugs and feature requests can be reported in Electron's [issue tracker](https://github.com/electron/electron/issues).
 
-
 ## Notable Changes
 
 ### Highlights
 
-- Added an event to help unlock cryptographic devices when a PIN is needed. [#41205](https://github.com/electron/electron/pull/41205) 
+- Added an event to help unlock cryptographic devices when a PIN is needed. [#41205](https://github.com/electron/electron/pull/41205)
 - Extended `navigationHistory` API with 2 new functions for better history management. [#42014](https://github.com/electron/electron/pull/42014)
 - Improved native theme transparency checking. [#42862](https://github.com/electron/electron/pull/42862)
 
@@ -37,10 +36,10 @@ Electron 33 upgrades Chromium from `128.0.6613.36` to `130.0.6723.44`, Node from
 
 ### New Features
 
-* Added the event `client-certificate-request-password` to app. It is dispatched when a PIN is needed to unlock a cryptographic device. [#41205](https://github.com/electron/electron/pull/41205)
-* Added error event in utility process to support diagnostic reports on V8 fatal errors. [#43997](https://github.com/electron/electron/pull/43997)
-* Added `View.setBorderRadius(radius)` for customizing the border radius of views—with compatibility for `WebContentsView`. [#42320](https://github.com/electron/electron/pull/42320)
-* Extended `navigationHistory` API with 2 new functions for better history management. [#42014](https://github.com/electron/electron/pull/42014)
+- Added the event `client-certificate-request-password` to app. It is dispatched when a PIN is needed to unlock a cryptographic device. [#41205](https://github.com/electron/electron/pull/41205)
+- Added error event in utility process to support diagnostic reports on V8 fatal errors. [#43997](https://github.com/electron/electron/pull/43997)
+- Added `View.setBorderRadius(radius)` for customizing the border radius of views—with compatibility for `WebContentsView`. [#42320](https://github.com/electron/electron/pull/42320)
+- Extended `navigationHistory` API with 2 new functions for better history management. [#42014](https://github.com/electron/electron/pull/42014)
 
 ### Breaking Changes
 
@@ -53,29 +52,37 @@ or later will be required to run Electron v33.0.0 and higher.
 
 #### Behavior Changed: custom protocol URL handling on Windows
 
-Due to changes made in Chromium to support [Non-Special Scheme URLs](http://bit.ly/url-non-special), custom protocol URLs that use Windows file paths will no longer work correctly with the deprecated `protocol.registerFileProtocol` and the `baseURLForDataURL` property on `BrowserWindow.loadURL`, `WebContents.loadURL`, and `<webview>.loadURL`.  `protocol.handle` will also not work with these types of URLs but this is not a change since it has always worked that way.
+Due to changes made in Chromium to support [Non-Special Scheme URLs](http://bit.ly/url-non-special), custom protocol URLs that use Windows file paths will no longer work correctly with the deprecated `protocol.registerFileProtocol` and the `baseURLForDataURL` property on `BrowserWindow.loadURL`, `WebContents.loadURL`, and `<webview>.loadURL`. `protocol.handle` will also not work with these types of URLs but this is not a change since it has always worked that way.
 
 ```js
 // No longer works
 protocol.registerFileProtocol('other', () => {
-  callback({ filePath: '/path/to/my/file' })
-})
+  callback({ filePath: '/path/to/my/file' });
+});
 
-const mainWindow = new BrowserWindow()
-mainWindow.loadURL('data:text/html,<script src="loaded-from-dataurl.js"></script>', { baseURLForDataURL: 'other://C:\\myapp' })
-mainWindow.loadURL('other://C:\\myapp\\index.html')
+const mainWindow = new BrowserWindow();
+mainWindow.loadURL(
+  'data:text/html,<script src="loaded-from-dataurl.js"></script>',
+  { baseURLForDataURL: 'other://C:\\myapp' }
+);
+mainWindow.loadURL('other://C:\\myapp\\index.html');
 
 // Replace with
-const path = require('node:path')
-const nodeUrl = require('node:url')
+const path = require('node:path');
+const nodeUrl = require('node:url');
 protocol.handle(other, (req) => {
-  const srcPath = 'C:\\myapp\\'
-  const reqURL = new URL(req.url)
-  return net.fetch(nodeUrl.pathToFileURL(path.join(srcPath, reqURL.pathname)).toString())
-})
+  const srcPath = 'C:\\myapp\\';
+  const reqURL = new URL(req.url);
+  return net.fetch(
+    nodeUrl.pathToFileURL(path.join(srcPath, reqURL.pathname)).toString()
+  );
+});
 
-mainWindow.loadURL('data:text/html,<script src="loaded-from-dataurl.js"></script>', { baseURLForDataURL: 'other://' })
-mainWindow.loadURL('other://index.html')
+mainWindow.loadURL(
+  'data:text/html,<script src="loaded-from-dataurl.js"></script>',
+  { baseURLForDataURL: 'other://' }
+);
+mainWindow.loadURL('other://index.html');
 ```
 
 #### Behavior Changed: `webContents` property on `login` on `app`
@@ -94,21 +101,22 @@ The `systemPreferences.accessibilityDisplayShouldReduceTransparency` property is
 
 ```js
 // Deprecated
-const shouldReduceTransparency = systemPreferences.accessibilityDisplayShouldReduceTransparency
+const shouldReduceTransparency =
+  systemPreferences.accessibilityDisplayShouldReduceTransparency;
 
 // Replace with:
-const prefersReducedTransparency = nativeTheme.prefersReducedTransparency
+const prefersReducedTransparency = nativeTheme.prefersReducedTransparency;
 ```
 
 ## End of Support for 30.x.y
 
 Electron 30.x.y has reached end-of-support as per the project's [support policy](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#version-support-policy). Developers and applications are encouraged to upgrade to a newer version of Electron.
 
-| E33 (Oct'24) | E34 (Jan'25) | E35 (Apr'25)
-| ------------ | ------------ | ------------
-| 33.x.y       | 34.x.y       | 35.x.y
-| 32.x.y       | 33.x.y       | 34.x.y
-| 31.x.y       | 32.x.y       | 33.x.y
+| E33 (Oct'24) | E34 (Jan'25) | E35 (Apr'25) |
+| ------------ | ------------ | ------------ |
+| 33.x.y       | 34.x.y       | 35.x.y       |
+| 32.x.y       | 33.x.y       | 34.x.y       |
+| 31.x.y       | 32.x.y       | 33.x.y       |
 
 ## What's Next
 
@@ -117,6 +125,3 @@ In the short term, you can expect the team to continue to focus on keeping up wi
 You can find [Electron's public timeline here](https://www.electronjs.org/docs/latest/tutorial/electron-timelines).
 
 More information about future changes can be found on the [Planned Breaking Changes](https://github.com/electron/electron/blob/main/docs/breaking-changes.md) page.
-
-
-

--- a/blog/electron-33-0.md
+++ b/blog/electron-33-0.md
@@ -35,7 +35,14 @@ Electron 33 upgrades Chromium from `128.0.6613.36` to `130.0.6723.44`, Node from
 
 ### New Features
 
-FIXME
+* Added the event `client-certificate-request-password` to app. It is dispatched when a PIN is needed to unlock a cryptographic device. [#41205](https://github.com/electron/electron/pull/41205) 
+* Added error event in utility process to support diagnostic reports on V8 fatal errors. [#43997](https://github.com/electron/electron/pull/43997) 
+* Added `View.setBorderRadius(radius)` for customizing the border radius of views—with compatibility for `WebContentsView`. [#42320](https://github.com/electron/electron/pull/42320) 
+* Added Linux support for the Windows Control Overlay API. [#41769](https://github.com/electron/electron/pull/41769) <span style="font-size:small;">(Also in [30](https://github.com/electron/electron/pull/42683), [31](https://github.com/electron/electron/pull/42682), [32](https://github.com/electron/electron/pull/42681))</span>
+* Added support for the macOS system picker in `desktopCapturer` and `setDisplayMediaRequestHandler`. [#43680](https://github.com/electron/electron/pull/43680) <span style="font-size:small;">(Also in [32](https://github.com/electron/electron/pull/43679))</span>
+* Added `DownloadItem.getCurrentBytesPerSecond()`, `DownloadItem.getPercentComplete()`, `DownloadItem.getEndTime()`. [#42805](https://github.com/electron/electron/pull/42805) <span style="font-size:small;">(Also in [30](https://github.com/electron/electron/pull/42914), [31](https://github.com/electron/electron/pull/42915), [32](https://github.com/electron/electron/pull/42913))</span>
+* Added a new property `prefersReducedTransparency` to `nativeTheme`, which indicates whether the user has chosen to reduce OS-level transparency via system accessibility settings. [#42862](https://github.com/electron/electron/pull/42862) <span style="font-size:small;">(Also in [30](https://github.com/electron/electron/pull/43138), [31](https://github.com/electron/electron/pull/43137), [32](https://github.com/electron/electron/pull/43024))</span>
+* Added support for responding to auth requests initiated from utility process via `app#login` event. [#42631](https://github.com/electron/electron/pull/42631) <span style="font-size:small;">(Also in [32](https://github.com/electron/electron/pull/43317))</span>
 
 ### Breaking Changes
 

--- a/blog/electron-33-0.md
+++ b/blog/electron-33-0.md
@@ -50,9 +50,9 @@ macOS 10.15 (Catalina) is no longer supported by [Chromium](https://chromium-rev
 Older versions of Electron will continue to run on Catalina, but macOS 11 (Big Sur)
 or later will be required to run Electron v33.0.0 and higher.
 
-#### Node is built with c++20
+#### Behavior Changed: Native modules now require C++20
 
-Both [V8](https://chromium-review.googlesource.com/c/v8/v8/+/5587859) and [Node.js](https://github.com/nodejs/node/pull/45427) now require C++20, so native node modules should be built with `--std=c++20` rather than `--std=c++17`.
+Due to changes made upstream, both [V8](https://chromium-review.googlesource.com/c/v8/v8/+/5587859) and [Node.js](https://github.com/nodejs/node/pull/45427) now require C++20 as a minimum version. Developers using native node modules should build their modiles with `--std=c++20` rather than `--std=c++17`. Images using gcc9 or lower may need to update to gcc10 in order to compile. See [#43555](https://github.com/electron/electron/pull/43555) for more details.
 
 #### Behavior Changed: custom protocol URL handling on Windows
 

--- a/blog/electron-33-0.md
+++ b/blog/electron-33-0.md
@@ -50,6 +50,10 @@ macOS 10.15 (Catalina) is no longer supported by [Chromium](https://chromium-rev
 Older versions of Electron will continue to run on Catalina, but macOS 11 (Big Sur)
 or later will be required to run Electron v33.0.0 and higher.
 
+#### Node is built with c++20
+
+Both [V8](https://chromium-review.googlesource.com/c/v8/v8/+/5587859) and [Node.js](https://github.com/nodejs/node/pull/45427) now require C++20, so native node modules should be built with `--std=c++20` rather than `--std=c++17`.
+
 #### Behavior Changed: custom protocol URL handling on Windows
 
 Due to changes made in Chromium to support [Non-Special Scheme URLs](http://bit.ly/url-non-special), custom protocol URLs that use Windows file paths will no longer work correctly with the deprecated `protocol.registerFileProtocol` and the `baseURLForDataURL` property on `BrowserWindow.loadURL`, `WebContents.loadURL`, and `<webview>.loadURL`. `protocol.handle` will also not work with these types of URLs but this is not a change since it has always worked that way.

--- a/blog/electron-33-0.md
+++ b/blog/electron-33-0.md
@@ -88,7 +88,7 @@ mainWindow.loadURL('other://index.html');
 #### Behavior Changed: `webContents` property on `login` on `app`
 
 The `webContents` property in the `login` event from `app` will be `null`
-when the event is triggered for requests from the [utility process](api/utility-process.md)
+when the event is triggered for requests from the [utility process](https://www.electronjs.org/docs/latest/api/utility-process)
 created with `respondToAuthRequestsFromMainProcess` option.
 
 #### Deprecated: `textured` option in `BrowserWindowConstructorOption.type`

--- a/blog/electron-33-0.md
+++ b/blog/electron-33-0.md
@@ -18,7 +18,7 @@ If you have any feedback, please share it with us on [Twitter](https://twitter.c
 
 ### Highlights
 
-- Added an event to help unlock cryptographic devices when a PIN is needed. [#41205](https://github.com/electron/electron/pull/41205)
+- Added a handler, `app.setClientCertRequestPasswordHandler(handler)`, to help unlock cryptographic devices when a PIN is needed. [#41205](https://github.com/electron/electron/pull/41205)
 - Extended `navigationHistory` API with 2 new functions for better history management. [#42014](https://github.com/electron/electron/pull/42014)
 - Improved native theme transparency checking. [#42862](https://github.com/electron/electron/pull/42862)
 
@@ -36,7 +36,7 @@ Electron 33 upgrades Chromium from `128.0.6613.36` to `130.0.6723.44`, Node from
 
 ### New Features
 
-- Added the event `client-certificate-request-password` to app. It is dispatched when a PIN is needed to unlock a cryptographic device. [#41205](https://github.com/electron/electron/pull/41205)
+- Added a handler, `app.setClientCertRequestPasswordHandler(handler)`, to help unlock cryptographic devices when a PIN is needed. [#41205](https://github.com/electron/electron/pull/41205)
 - Added error event in utility process to support diagnostic reports on V8 fatal errors. [#43997](https://github.com/electron/electron/pull/43997)
 - Added `View.setBorderRadius(radius)` for customizing the border radius of views—with compatibility for `WebContentsView`. [#42320](https://github.com/electron/electron/pull/42320)
 - Extended `navigationHistory` API with 2 new functions for better history management. [#42014](https://github.com/electron/electron/pull/42014)

--- a/blog/electron-33-0.md
+++ b/blog/electron-33-0.md
@@ -1,0 +1,63 @@
+---
+title: Electron 33.0.0
+date: 2024-10-14T00:00:00.000Z
+authors: ckerr
+slug: electron-33-0
+tags: [release]
+---
+
+Electron 33.0.0 has been released! It includes upgrades to Chromium 130.0.6723.44, V8 13.0, and Node 20.18.0.
+
+---
+
+The Electron team is excited to announce the release of Electron 33.0.0! You can install it with npm via `npm install electron@latest` or download it from our [releases website](https://releases.electronjs.org/releases/stable). Continue reading for details about this release.
+
+If you have any feedback, please share it with us on [Twitter](https://twitter.com/electronjs) or [Mastodon](https://social.lfx.dev/@electronjs), or join our community [Discord](https://discord.com/invite/electronjs)! Bugs and feature requests can be reported in Electron's [issue tracker](https://github.com/electron/electron/issues).
+
+
+## Notable Changes
+
+### Highlights
+
+FIXME
+
+### Stack Changes
+
+- Chromium `130.0.6723.44`
+  - [New in 130](https://developer.chrome.com/blog/new-in-chrome-130/)
+  - [New in 129](https://developer.chrome.com/blog/new-in-chrome-129/)
+- Node `20.18.0`
+  - [Node 20.18.0 blog post](https://nodejs.org/en/blog/release/v20.18.0/)
+  - [Node 20.17.0 blog post](https://nodejs.org/en/blog/release/v20.17.0/)
+- V8 `13.0`
+
+Electron 33 upgrades Chromium from `128.0.6613.36` to `130.0.6723.44`, Node from `20.16.0` to `20.18.0`, and V8 from `12.8` to `13.0`.
+
+### New Features
+
+FIXME
+
+### Breaking Changes
+
+FIXME
+
+## End of Support for 30.x.y
+
+Electron 30.x.y has reached end-of-support as per the project's [support policy](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#version-support-policy). Developers and applications are encouraged to upgrade to a newer version of Electron.
+
+| E33 (Oct'24) | E34 (Jan'25) | E35 (Apr'25)
+| ------------ | ------------ | ------------
+| 33.x.y       | 34.x.y       | 35.x.y
+| 32.x.y       | 33.x.y       | 34.x.y
+| 31.x.y       | 32.x.y       | 33.x.y
+
+## What's Next
+
+In the short term, you can expect the team to continue to focus on keeping up with the development of the major components that make up Electron, including Chromium, Node, and V8.
+
+You can find [Electron's public timeline here](https://www.electronjs.org/docs/latest/tutorial/electron-timelines).
+
+More information about future changes can be found on the [Planned Breaking Changes](https://github.com/electron/electron/blob/main/docs/breaking-changes.md) page.
+
+
+


### PR DESCRIPTION
This PR adds a new blog post for Electron 33. @electron/wg-releases, @electron/wg-outreach

Merge target: October 15th, after 33.0.0 releases.

⚠️ Do not merge until the following are completed ⚠️ 

* [x]   Update node, v8 and chromium versions from final chrome roll under Stack Changes section
* [x]   Edit link for M130 "New In Chrome" blog post
* [x]   Add a few bullets for New Features section
* [x]   Add any missing items in Breaking Changes section
* [x]   Update End of Support

_Note: The "Check Blog links" job is going to fail until the Chrome 130 announcement blog comes out. A fail is expected until about Tuesday_