### PR TITLE
ci: remove unused branch argument to pre-build script

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -5,10 +5,6 @@ on:
     types: [doc_changes]
   workflow_dispatch:
     inputs:
-      branch:
-        type: string
-        description: The branch of the commit, usually something like `15-x-y`
-        required: true
       sha:
         type: string
         description: The SHA of the `electron/electron` commit
@@ -36,7 +32,7 @@ jobs:
         uses: bahmutov/npm-install@dc9579d3dfb9c0e7a1f56c194eefcb8e2c9f0da5 # tag: v1.10.3
       - name: Prebuild
         run: |
-          yarn pre-build ${{ github.event.client_payload.sha || github.event.inputs.sha }} ${{ github.event.client_payload.branch || github.event.inputs.branch }}
+          yarn pre-build ${{ github.event.client_payload.sha || github.event.inputs.sha }}
           git add .
       - name: Push changes
         uses: dsanders11/github-app-commit-action@43de6da2f4d927e997c0784c7a0b61bd19ad6aac # v1.5.0


### PR DESCRIPTION
We snipped this from the script in #327 so it's being unused and we should remove it to avoid confusion.