### PR TITLE
chore: allow running pre-build without SHA target

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1,6 +1,7 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
+import logger from '@docusaurus/logger';
 import { Config } from '@docusaurus/types';
 import npm2yarn from '@docusaurus/remark-plugin-npm2yarn';
 import { themes as prismThemes } from 'prism-react-renderer';
@@ -25,7 +26,7 @@ try {
     'utf-8'
   );
 } catch {
-  console.warn('No .sha file found in docs/latest directory');
+  logger.warn('No .sha file found in docs/latest directory');
 }
 
 const config: Config = {

--- a/scripts/pre-build.ts
+++ b/scripts/pre-build.ts
@@ -53,8 +53,7 @@ const start = async (source: string): Promise<void> => {
       destination: DOCS_FOLDER,
       downloadMatch: '/docs/',
     });
-
-    await fs.writeFile(path.join(DOCS_FOLDER, '.sha'), source);
+    await fs.writeFile(path.join(DOCS_FOLDER, '.sha'), target);
   } else if (existsSync(source)) {
     await copy({
       target: source,


### PR DESCRIPTION
Running `yarn pre-build` fails locally otherwise, so this works around it.