### PR TITLE
ci: limit concurrency of update docs workflow

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -10,6 +10,8 @@ on:
         description: The SHA of the `electron/electron` commit
         required: true
 
+concurrency: update-docs
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
Parallel runs of this workflow will fail to commit the new docs updates because HEAD will have moved by the time the commit happens, see [this run](https://github.com/electron/website/actions/runs/12105783880).

This may still have event ordering issues when two merges happen quickly on `e/e`, leading to an older version of the docs being deployed. They'll be fixed in the future when we migrate to publishing tags/releases rather than specific SHAs.