### PR TITLE
blog: mention background color on WebContentsView

### DIFF
--- a/blog/migrate-to-webcontentsview.md
+++ b/blog/migrate-to-webcontentsview.md
@@ -42,8 +42,7 @@ For the most part, each instance where your app instantiates new BrowserViews ca
    :::info
 
    By default, `WebContentsView` instantiates with a white background, while `BrowserView` instantiates with a transparent background.
-   If you used to use the default transparent background setting with your `BrowserView` instances, you will need to set the
-   background colour manually with a RGBA hex value with the alpha (opaqueness) channel set to `00`.
+   To get a transparent background in `WebContentsView`, set its background color to an RGBA hex value with an alpha (opaqueness) channel set to `00`:
 
    ```diff
    + this.webContentsView.setBackgroundColor("#00000000");

--- a/blog/migrate-to-webcontentsview.md
+++ b/blog/migrate-to-webcontentsview.md
@@ -38,6 +38,10 @@ For the most part, each instance where your app instantiates new BrowserViews ca
    - this.tabBar = new BrowserView({
    + this.tabBar = new WebContentsView({
    ```
+   1a. `WebContentsView` instantiates with a white background, compared to `BrowserView` which defaults to a transparent background, if you took advantage of this default, you may need to manually set the background color
+      ```js
+      this.webContentsView.setBackgroundColor("#00000000");
+      ```
 
 2. Migrate where the `BrowserView` gets added to its parent window.
 

--- a/blog/migrate-to-webcontentsview.md
+++ b/blog/migrate-to-webcontentsview.md
@@ -38,10 +38,18 @@ For the most part, each instance where your app instantiates new BrowserViews ca
    - this.tabBar = new BrowserView({
    + this.tabBar = new WebContentsView({
    ```
-   1a. `WebContentsView` instantiates with a white background, compared to `BrowserView` which defaults to a transparent background, if you took advantage of this default, you may need to manually set the background color
-      ```js
-      this.webContentsView.setBackgroundColor("#00000000");
-      ```
+
+   :::info
+
+   By default, `WebContentsView` instantiates with a white background, while `BrowserView` instantiates with a transparent background.
+   If you used to use the default transparent background setting with your `BrowserView` instances, you will need to set the
+   background colour manually with a RGBA hex value with the alpha (opaqueness) channel set to `00`.
+
+   ```diff
+   + this.webContentsView.setBackgroundColor("#00000000");
+   ```
+
+   :::
 
 2. Migrate where the `BrowserView` gets added to its parent window.
 


### PR DESCRIPTION
Previously the `WebContentsView` migration guide/blog post did not mention the changed default background color of `WebContentsView` compared to `BrowserView`'s, this adds a note about that.

Closes [electron/#44914](https://github.com/electron/electron/issues/44914#issuecomment-2513233059)