### PR TITLE
fix: don't put index prop on sidebar links

### DIFF
--- a/src/theme/DocSidebarItem/Link/index.tsx
+++ b/src/theme/DocSidebarItem/Link/index.tsx
@@ -15,6 +15,7 @@ export default function DocSidebarItemLink({
   onItemClick,
   activePath,
   level,
+  index,
   ...props
 }: Props): JSX.Element {
   const { href, label, className, autoAddBaseUrl, customProps } = item;


### PR DESCRIPTION
Refs https://github.com/facebook/docusaurus/blob/a99586531473678d2c47d8576971e496777fb617/packages/docusaurus-theme-classic/src/theme/DocSidebarItem/Link/index.tsx#L19-L26.

Currently `index="<N>"` is getting added to the sidebar links, which is not valid HTML.