### PR TITLE
fix: Use correct theme data in carousel

### DIFF
--- a/src/pages/home/_components/FeaturedAppsCarousel.tsx
+++ b/src/pages/home/_components/FeaturedAppsCarousel.tsx
@@ -11,8 +11,12 @@ interface FeaturedAppsCarouselProps {
 export default function FeaturedAppsCarousel({
   list,
 }: FeaturedAppsCarouselProps) {
+  const [isDarkTheme, setIsDarkTheme] = React.useState(false);
   const { colorMode } = useColorMode();
-  const isDarkTheme = colorMode === 'dark';
+
+  React.useEffect(() => {
+    setIsDarkTheme(colorMode === 'dark');
+  }, [colorMode]);
 
   return (
     <div className={clsx(styles.section)}>


### PR DESCRIPTION
This fix ensures that the carousel always uses the correct theme during initial render. Previously, if the system theme was set to dark and you load the page, the logos were dark instead of the expected light. 