### PR TITLE
chore: clear linting warning

### DIFF
--- a/src/theme/DocSidebarItem/Link/index.tsx
+++ b/src/theme/DocSidebarItem/Link/index.tsx
@@ -15,7 +15,7 @@ export default function DocSidebarItemLink({
   onItemClick,
   activePath,
   level,
-  index,
+  index, // eslint-disable-line @typescript-eslint/no-unused-vars
   ...props
 }: Props): JSX.Element {
   const { href, label, className, autoAddBaseUrl, customProps } = item;


### PR DESCRIPTION
Didn't notice the linting warning in #701, so clearing that and this also makes it more clear that we're intentionally including the unused variable.