### PR TITLE
chore: tweak docs version audit to work with latest version

### DIFF
--- a/.github/workflows/audit-docs-version.yml
+++ b/.github/workflows/audit-docs-version.yml
@@ -20,7 +20,7 @@ jobs:
             const { setTimeout } = await import('node:timers/promises');
             const { ElectronVersions } = await import('${{ github.workspace }}/node_modules/@electron/fiddle-core/dist/index.js');
 
-            const DOCS_SHA_REGEX = /<meta name="docs-sha" content="(\w+)">/m;
+            const DOCS_SHA_REGEX = /<meta name="?docs-sha"? content="?(\w+)"?>/m;
             const DELTA_THRESHOLD_MS = 1000*60*20;
 
             const resp = await fetch('https://electronjs.org');


### PR DESCRIPTION
I think a side effect of #703 is that there are no longer quotes around the values being looked for by the audit, so make them optional.