### PR TITLE
fix: move ul elements outside of p element

### DIFF
--- a/src/pages/community/index.tsx
+++ b/src/pages/community/index.tsx
@@ -70,37 +70,37 @@ function Community() {
           The Electron community spans the globe, and English is not
           everyone&apos;s first language. Find documentation in your language on
           this website, or join one of the language communities below:
-          <ul>
-            <li>
-              <a href="https://discord.gg/eZTKXHBKpK">electron-zh</a>{' '}
-              <i>(Chinese)</i>
-            </li>
-            <li>
-              <a href="https://telegram.me/electron_ru">electron-ru</a>{' '}
-              <i>(Russian)</i>
-            </li>
-            <li>
-              <a href="https://electron-br.slack.com/">electron-br</a>{' '}
-              <i>(Brazilian Portuguese)</i>
-            </li>
-            <li>
-              <a href="https://electron-jp.slack.com/">electron-jp</a>{' '}
-              <i>(Japanese)</i>
-            </li>
-            <li>
-              <a href="https://electron-tr.herokuapp.com/">electron-tr</a>{' '}
-              <i>(Turkish)</i>
-            </li>
-            <li>
-              <a href="https://electron-id.slack.com/">electron-id</a>{' '}
-              <i>(Indonesian)</i>
-            </li>
-            <li>
-              <a href="https://electronpl.github.io/">electron-pl</a>{' '}
-              <i>(Polish)</i>
-            </li>
-          </ul>
         </p>
+        <ul>
+          <li>
+            <a href="https://discord.gg/eZTKXHBKpK">electron-zh</a>{' '}
+            <i>(Chinese)</i>
+          </li>
+          <li>
+            <a href="https://telegram.me/electron_ru">electron-ru</a>{' '}
+            <i>(Russian)</i>
+          </li>
+          <li>
+            <a href="https://electron-br.slack.com/">electron-br</a>{' '}
+            <i>(Brazilian Portuguese)</i>
+          </li>
+          <li>
+            <a href="https://electron-jp.slack.com/">electron-jp</a>{' '}
+            <i>(Japanese)</i>
+          </li>
+          <li>
+            <a href="https://electron-tr.herokuapp.com/">electron-tr</a>{' '}
+            <i>(Turkish)</i>
+          </li>
+          <li>
+            <a href="https://electron-id.slack.com/">electron-id</a>{' '}
+            <i>(Indonesian)</i>
+          </li>
+          <li>
+            <a href="https://electronpl.github.io/">electron-pl</a>{' '}
+            <i>(Polish)</i>
+          </li>
+        </ul>
       </div>
     </Layout>
   );


### PR DESCRIPTION
This got [flagged by the Docusaurus build with a somewhat cryptic warning](https://github.com/electron/website/actions/runs/12363701773/job/34505551503#step:11:12):

```
- "/community/":
  - [HTML minifier diagnostic - error] No "p" element in scope but a "p" end tag seen - {"primary_spans":[{"end":14736,"start":14732}],"span_labels":[]}
```

The reason the warning says no `p` element is in scope but it sees a `p` end tag is that the `ul` element closes the `p` element and [is considered to be omitted](https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element):

> A [`p`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element) element's [end tag](https://html.spec.whatwg.org/multipage/syntax.html#syntax-end-tag) can be omitted if the [`p`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element) element is immediately followed by an [...] or [`ul`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element) element

So then the HTML processing sees the `p` end tag but doesn't consider a `p` element to be open.

Also [from the spec](https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element), this is explicitly called out in a note and an example is given:

> List elements (in particular, [`ol`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element) and [`ul`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element) elements) cannot be children of [`p`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element) elements.

Fix is trivial, but wanted to give a comprehensive explanation. 🙂 