### PR TITLE
chore: rework the get started section

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -5,20 +5,18 @@ module.exports = {
       label: 'Get Started',
       items: [
         'latest/tutorial/introduction',
-        'latest/tutorial/quick-start',
-        'latest/tutorial/installation',
-      ],
-    },
-    {
-      type: 'category',
-      label: 'Tutorial',
-      items: [
-        'latest/tutorial/tutorial-1-prerequisites',
-        'latest/tutorial/tutorial-2-first-app',
-        'latest/tutorial/tutorial-3-preload',
-        'latest/tutorial/tutorial-4-adding-features',
-        'latest/tutorial/tutorial-5-packaging',
-        'latest/tutorial/tutorial-6-publishing-updating',
+        {
+          type: 'category',
+          label: 'Tutorial',
+          items: [
+            'latest/tutorial/tutorial-1-prerequisites',
+            'latest/tutorial/tutorial-2-first-app',
+            'latest/tutorial/tutorial-3-preload',
+            'latest/tutorial/tutorial-4-adding-features',
+            'latest/tutorial/tutorial-5-packaging',
+            'latest/tutorial/tutorial-6-publishing-updating',
+          ],
+        },
       ],
     },
     {
@@ -103,6 +101,7 @@ module.exports = {
       label: 'Development',
       items: [
         'latest/tutorial/accessibility',
+        'latest/tutorial/installation',
         'latest/tutorial/asar-archives',
         'latest/tutorial/asar-integrity',
         'latest/tutorial/boilerplates-and-clis',


### PR DESCRIPTION
This PR
- removes quickstart from the sidebar
- moves tutorial to be a subsection of `Get Started`
- moves Advanced Installation to the `Development` section