### PR TITLE
chore: add styling to precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     ]
   },
   "lint-staged": {
-    "*.{html,json,md,yml}": "prettier --write",
+    "*.{html,json,md,yml,css,scss}": "prettier --write",
     "*.{js,jsx,ts,tsx}": [
       "prettier --write",
       "eslint --fix"


### PR DESCRIPTION
Avoids the issue of pushing PRs with styles that don't pass the lint check.