### PR TITLE
fix: avoid leaking `h2` styles globally

### DIFF
--- a/src/pages/home/_components/FeaturedAppsCarousel.module.scss
+++ b/src/pages/home/_components/FeaturedAppsCarousel.module.scss
@@ -1,4 +1,4 @@
-h2 {
+.heading {
   font-size: 2.5em;
   font-weight: 900;
 }

--- a/src/pages/home/_components/FeaturedAppsCarousel.tsx
+++ b/src/pages/home/_components/FeaturedAppsCarousel.tsx
@@ -21,7 +21,7 @@ export default function FeaturedAppsCarousel({
   return (
     <div className={clsx(styles.section)}>
       <div style={{ textAlign: 'center', marginBottom: '6rem' }}>
-        <h2>Trusted by best-in-class apps</h2>
+        <h2 className={styles.heading}>Trusted by best-in-class apps</h2>
         <p>
           {
             'Popular consumer and rock-solid enterprise apps use Electron to power their desktop experiences.'


### PR DESCRIPTION
Some styles from #676 were leaking because Docusaurus exports a single giant CSS file for consumption (ref https://github.com/facebook/docusaurus/issues/6228).

By querying `h2` directly, this rule was applying to every `h2` tag that didn't have any higher specificity rule attached to it.