### PR TITLE
refactor: replace `globby` with `fs.glob`

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.28.0",
     "execa": "^5.0.0",
-    "globby": "^11.0.3",
     "gray-matter": "^4.0.3",
     "gunzip-maybe": "^1.4.2",
     "hast-util-from-html": "^2.0.1",

--- a/scripts/tasks/add-frontmatter.ts
+++ b/scripts/tasks/add-frontmatter.ts
@@ -1,8 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import globby from 'globby';
-
 /*
   To make `/docs/latest` have content we need to set the
   slug of a particular page to `/latest/`. `START_PAGE` is how we
@@ -16,10 +14,10 @@ const START_PAGE = 'tutorial/introduction.md';
  * @returns A Map of file paths and their corresponding file contents
  */
 const getMarkdownFiles = async (startPath: string) => {
-  const filesPaths = await globby(path.posix.join(startPath, '**/*.md'));
+  const filesPaths = fs.glob(path.posix.join(startPath, '**/*.md'));
 
   const files = new Map();
-  for (const filePath of filesPaths) {
+  for await (const filePath of filesPaths) {
     const content = await fs.readFile(filePath, 'utf-8');
     files.set(filePath, content);
   }

--- a/scripts/tasks/download-docs.ts
+++ b/scripts/tasks/download-docs.ts
@@ -4,7 +4,6 @@ import stream from 'node:stream';
 import type { ReadableStream } from 'node:stream/web';
 
 import tar from 'tar-stream';
-import globby from 'globby';
 
 interface DownloadOptions {
   /** The GitHub organization to download the contents from */
@@ -144,13 +143,13 @@ export const copy = async ({
   destination,
   copyMatch = '.',
 }: CopyOptions) => {
-  const filesPaths = await globby(`${copyMatch}/**/*`, {
+  const filesPaths = fs.glob(`${copyMatch}/**/*`, {
     cwd: target,
   });
 
   const contents = [];
 
-  for (const filePath of filesPaths) {
+  for await (const filePath of filesPaths) {
     const content = {
       filename: filePath.replace(`${copyMatch}/`, ''),
       content: await fs.readFile(path.join(target, filePath)),

--- a/scripts/tasks/md-fixers.ts
+++ b/scripts/tasks/md-fixers.ts
@@ -1,8 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import globby from 'globby';
-
 const fiddlePathFixRegex = /```fiddle docs\//;
 
 const fiddleTransformer = (line: string) => {
@@ -122,11 +120,11 @@ const fixReturnLines = (content: string) => {
  * @param version
  */
 export const fixContent = async (root: string, version = 'latest') => {
-  const files = await globby(`${version}/**/*.md`, {
+  const files = fs.glob(`${version}/**/*.md`, {
     cwd: root,
   });
 
-  for (const filePath of files) {
+  for await (const filePath of files) {
     const fullFilePath = path.join(root, filePath);
     const content = await fs.readFile(fullFilePath, 'utf-8');
 

--- a/scripts/tasks/preprocess-api-history.ts
+++ b/scripts/tasks/preprocess-api-history.ts
@@ -1,8 +1,9 @@
+import fs from 'node:fs/promises';
+
 import logger from '@docusaurus/logger';
 import Ajv, { JSONSchemaType, ValidateFunction } from 'ajv';
 import { readFile, writeFile } from 'fs/promises';
 import { fromHtml } from 'hast-util-from-html';
-import globby from 'globby';
 import type { Html, Root } from 'mdast';
 import { fromMarkdown } from 'mdast-util-from-markdown';
 import path from 'path';
@@ -32,10 +33,10 @@ let hasWarned = false;
 
 // Copied from here: <https://github.com/electron/website/blob/feat/api-history/scripts/tasks/add-frontmatter.ts#L16-L23>
 const getMarkdownFiles = async (startPath: string) => {
-  const filesPaths = await globby(path.posix.join(startPath, 'api', '/*.md'));
+  const filesPaths = fs.glob(path.posix.join(startPath, 'api', '/*.md'));
 
   const files: Map<string, string> = new Map();
-  for (const filePath of filesPaths) {
+  for await (const filePath of filesPaths) {
     const content = await readFile(filePath, 'utf-8');
     files.set(filePath, content);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8378,7 +8378,7 @@ globby@14.0.1:
     slash "^5.1.0"
     unicorn-magic "^0.1.0"
 
-globby@^11.0.1, globby@^11.0.3, globby@^11.0.4, globby@^11.1.0:
+globby@^11.0.1, globby@^11.0.4, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==


### PR DESCRIPTION
This PR stacks on top of #743. Replaces `globby` with the new `fs.glob` introduced in Node 22.