### PR TITLE
style: align markdown width with container

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -108,8 +108,6 @@
 }
 
 .theme-doc-markdown {
-  max-width: 700px;
-  margin: 0 auto;
   margin-top: 2rem;
 }
 

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -107,8 +107,10 @@
   }
 }
 
-.theme-doc-markdown {
-  margin-top: 2rem;
+@media (min-width: 1440px) {
+  .container {
+    max-width: var(--ifm-container-width);
+  }
 }
 
 .navbar {


### PR DESCRIPTION
A less hacky way to avoid the XL markdown width that Docusaurus comes with by default. Makes the DocCardList view more pleasant and aligns our Markdown content width with our buttons.

| Before | After |
|--------|-------|
|![image](https://github.com/user-attachments/assets/1b254fa5-db06-4832-84ee-38eb7e56d358)| ![image](https://github.com/user-attachments/assets/c799bab3-86db-43cc-9bed-a86068f8655a) |

