### PR TITLE
style: fix inline code baseline alignment

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -284,3 +284,7 @@
   height: 24px;
   width: 24px;
 }
+
+code {
+  vertical-align: baseline;
+}

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -179,6 +179,11 @@
     --ifm-h5-font-size: 0.8rem;
   }
 
+  // Fixes inline code alignment in Firefox
+  code {
+    vertical-align: baseline;
+  }
+
   // We want this to only apply to inline code, so don't apply
   // this color to ``` code blocks nor any headings.
   :not(pre):not(h2):not(h3):not(h4):not(h5):not(h6) > code {
@@ -283,8 +288,4 @@
   display: flex;
   height: 24px;
   width: 24px;
-}
-
-code {
-  vertical-align: baseline;
 }

--- a/src/pages/home/_index.module.scss
+++ b/src/pages/home/_index.module.scss
@@ -101,3 +101,7 @@ summary {
   margin: 1rem;
   padding: 1.2rem;
 }
+
+code {
+  vertical-align: baseline;
+}

--- a/src/pages/home/_index.module.scss
+++ b/src/pages/home/_index.module.scss
@@ -101,7 +101,3 @@ summary {
   margin: 1rem;
   padding: 1.2rem;
 }
-
-code {
-  vertical-align: baseline;
-}


### PR DESCRIPTION
Summary
This PR fixes the issue where inline code (code elements) had a misaligned baseline on the Electron docs website when viewed on Mozilla 134.0.2 macOS.

Changes
Adjusted CSS styles to ensure proper alignment of inline code elements.
Verified the fix across different browsers to maintain consistency.

Testing
Tested on Mozilla 134.0.2 macOS ✅
Verified on Chrome and Safari to ensure no regressions ✅

Fixes #749