### PR TITLE
feat: add docs style-guide to sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -198,6 +198,7 @@ module.exports = {
             'latest/development/creating-api',
             'latest/development/patches',
             'latest/development/source-code-directory-structure',
+            'latest/development/style-guide',
             'latest/development/testing',
           ],
         },


### PR DESCRIPTION
Following https://github.com/electron/electron/pull/45639, let's add it to the right place in the sidebar. :)