### PR TITLE
feat: smooth background color transition when switching themes

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -34,7 +34,6 @@
   --electron-heading: var(--electron-color-mid);
   --electron-inline-code: var(--electron-color-secondary-mid);
   --ifm-navbar-item-padding-horizontal: 8px;
-  --ifm-background-color-transition: background-color 0.5s ease;
 
   --api-history-added: var(--ifm-color-success-lighter);
   --api-history-deprecated: var(--ifm-color-danger-light);
@@ -103,7 +102,8 @@
 }
 
 html {
-  transition: var(--ifm-background-color-transition);
+  // transition for background-color when theme is changed
+  transition: background-color 0.5s ease;
 }
 
 .hero {

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -10,6 +10,7 @@
 /* We maintain separate colours for light and dark mode */
 :root {
   // modified base colors
+  --ifm-background-color: #fff;
   --ifm-color-primary: var(--electron-color-mid);
   --ifm-color-primary-dark: #000885;
   --ifm-color-primary-darker: #000047;
@@ -33,6 +34,7 @@
   --electron-heading: var(--electron-color-mid);
   --electron-inline-code: var(--electron-color-secondary-mid);
   --ifm-navbar-item-padding-horizontal: 8px;
+  --ifm-background-color-transition: background-color 0.5s ease;
 
   --api-history-added: var(--ifm-color-success-lighter);
   --api-history-deprecated: var(--ifm-color-danger-light);
@@ -98,6 +100,10 @@
   --electron-inline-code: var(--electron-color-secondary-light);
   --api-history-added: var(--ifm-color-success-darker);
   --api-history-deprecated: var(--ifm-color-danger-darkest);
+}
+
+html {
+  transition: var(--ifm-background-color-transition);
 }
 
 .hero {


### PR DESCRIPTION
#### Description of Change
Fixes: https://github.com/electron/website/issues/785
Added 0.5s background color transition when switching between light and dark themes. 
Changed the default light theme background (--ifm-background-color) from transparent to #fff (matching Node.js documentation) to enable the transition which wouldn't be possible with transparent background.

![transtion](https://github.com/user-attachments/assets/e383b9da-ae4e-4b4b-bb4f-791ef22ce18c)


CC @erickzhao 




#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)