### PR TITLE
build: use `yarn install` directly

### DIFF
--- a/.github/workflows/check-blog-links.yml
+++ b/.github/workflows/check-blog-links.yml
@@ -19,8 +19,9 @@ jobs:
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version-file: '.nvmrc'
+          cache: 'yarn'
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Check blog post links
         run: |
           BLOG_POSTS=$(gh api repos/electron/website/pulls/${{ github.event.pull_request.number }}/files --jq '.[] | select((.filename | startswith("blog/")) and (.status != "removed")) | .filename')

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # tag: v4.3.0
         with:
           node-version-file: '.nvmrc'
-
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@6cee6086f1bf4467050e9a51e94bfb71b44cbc39 # tag: v1.10.8
+        run: yarn install --frozen-lockfile
 
       - name: Lint
         run: yarn lint

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - name: Install dependencies
-        uses: bahmutov/npm-install@6cee6086f1bf4467050e9a51e94bfb71b44cbc39 # tag: v1.10.8
+        run: yarn install --frozen-lockfile
       - name: Upload sources to Crowdin
         run: 'yarn i18n:upload'
         env:
@@ -45,8 +45,8 @@ jobs:
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # tag: v4.3.0
         with:
           node-version-file: '.nvmrc'
-      - name: Install dependencies
-        uses: bahmutov/npm-install@6cee6086f1bf4467050e9a51e94bfb71b44cbc39 # tag: v1.10.8
+      - name: Install
+        run: yarn install --frozen-lockfile
       - name: Lint
         run: yarn lint
         env:

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # tag: v4.3.0
         with:
           node-version-file: '.nvmrc'
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Upload sources to Crowdin
@@ -45,7 +46,8 @@ jobs:
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # tag: v4.3.0
         with:
           node-version-file: '.nvmrc'
-      - name: Install
+          cache: 'yarn'
+      - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Lint
         run: yarn lint

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - name: Install dependencies
-        uses: bahmutov/npm-install@6cee6086f1bf4467050e9a51e94bfb71b44cbc39 # tag: v1.10.8
+        run: yarn install --frozen-lockfile
       - name: Prebuild
         run: |
           yarn pre-build ${{ github.event.client_payload.sha || github.event.inputs.sha }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # tag: v4.3.0
         with:
           node-version-file: '.nvmrc'
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Prebuild

--- a/.github/workflows/update-i18n-deploy.yml
+++ b/.github/workflows/update-i18n-deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # tag: v4.3.0
         with:
           node-version-file: '.nvmrc'
-
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/update-i18n-deploy.yml
+++ b/.github/workflows/update-i18n-deploy.yml
@@ -20,7 +20,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install dependencies
-        uses: bahmutov/npm-install@6cee6086f1bf4467050e9a51e94bfb71b44cbc39 # tag: v1.10.8
+        run: yarn install --frozen-lockfile
 
       - name: Download crowdin translation
         run: yarn i18n:download


### PR DESCRIPTION
I'm not sure why we opted to use a separate Action for running `yarn install`, but this PR attempts to reduce our number of GHA dependencies by just calling `yarn` directly.
