### PR TITLE
fixes issue (#786) website build failed 

### DIFF
--- a/create-electron-documentation/package-lock.json
+++ b/create-electron-documentation/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "create-electron-documentation",
+  "version": "0.0.3",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "create-electron-documentation",
+      "version": "0.0.3",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "create-electron-documentation": "file:"
+      },
+      "bin": {
+        "create-electron-documentation": "index.js"
+      }
+    },
+    "node_modules/create-electron-documentation": {
+      "resolved": "",
+      "link": true
+    }
+  }
+}

--- a/create-electron-documentation/package.json
+++ b/create-electron-documentation/package.json
@@ -8,5 +8,8 @@
   },
   "main": "index.js",
   "author": "molant",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": {
+    "create-electron-documentation": "file:"
+  }
 }

--- a/docs/latest/api/structures/base-window-options.md
+++ b/docs/latest/api/structures/base-window-options.md
@@ -1,7 +1,7 @@
 ---
 title: "BaseWindowConstructorOptions Object"
 description: ""
-slug: base-window-options
+slug: /base-window-options
 hide_title: false
 ---
 
@@ -100,7 +100,7 @@ hide_title: false
     **Note:** This option is currently experimental.
 * `titleBarOverlay` Object | Boolean (optional) -  When using a frameless window in conjunction with `win.setWindowButtonVisibility(true)` on macOS or using a `titleBarStyle` so that the standard window controls ("traffic lights" on macOS) are visible, this property enables the Window Controls Overlay [JavaScript APIs][overlay-javascript-apis] and [CSS Environment Variables][overlay-css-env-vars]. Specifying `true` will result in an overlay with default system colors. Default is `false`.
   * `color` String (optional) _Windows_ _Linux_ - The CSS color of the Window Controls Overlay when enabled. Default is the system color.
-  * `symbolColor` String (optional) _Windows_ _Linux_ - The CSS color of the symbols on the Window Controls Overlay when enabled. Default is the system color.
+  * `symbolColor` String (optional) _Windows_ - The CSS color of the symbols on the Window Controls Overlay when enabled. Default is the system color.
   * `height` Integer (optional) - The height of the title bar and Window Controls Overlay in pixels. Default is system height.
 * `trafficLightPosition` [Point](point.md) (optional) _macOS_ -
   Set a custom position for the traffic light buttons in frameless windows.

--- a/docs/latest/api/structures/bluetooth-device.md
+++ b/docs/latest/api/structures/bluetooth-device.md
@@ -1,7 +1,7 @@
 ---
 title: "BluetoothDevice Object"
 description: ""
-slug: bluetooth-device
+slug: /bluetooth-device
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/browser-window-options.md
+++ b/docs/latest/api/structures/browser-window-options.md
@@ -1,7 +1,7 @@
 ---
 title: "BrowserWindowConstructorOptions Object extends `BaseWindowConstructorOptions`"
 description: ""
-slug: browser-window-options
+slug: /browser-window-options
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/certificate-principal.md
+++ b/docs/latest/api/structures/certificate-principal.md
@@ -1,7 +1,7 @@
 ---
 title: "CertificatePrincipal Object"
 description: ""
-slug: certificate-principal
+slug: /certificate-principal
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/certificate.md
+++ b/docs/latest/api/structures/certificate.md
@@ -1,7 +1,7 @@
 ---
 title: "Certificate Object"
 description: ""
-slug: certificate
+slug: /certificate
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/cookie.md
+++ b/docs/latest/api/structures/cookie.md
@@ -1,7 +1,7 @@
 ---
 title: "Cookie Object"
 description: ""
-slug: cookie
+slug: /cookie
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/cpu-usage.md
+++ b/docs/latest/api/structures/cpu-usage.md
@@ -1,7 +1,7 @@
 ---
 title: "CPUUsage Object"
 description: ""
-slug: cpu-usage
+slug: /cpu-usage
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/crash-report.md
+++ b/docs/latest/api/structures/crash-report.md
@@ -1,7 +1,7 @@
 ---
 title: "CrashReport Object"
 description: ""
-slug: crash-report
+slug: /crash-report
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/custom-scheme.md
+++ b/docs/latest/api/structures/custom-scheme.md
@@ -1,7 +1,7 @@
 ---
 title: "CustomScheme Object"
 description: ""
-slug: custom-scheme
+slug: /custom-scheme
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/desktop-capturer-source.md
+++ b/docs/latest/api/structures/desktop-capturer-source.md
@@ -1,7 +1,7 @@
 ---
 title: "DesktopCapturerSource Object"
 description: ""
-slug: desktop-capturer-source
+slug: /desktop-capturer-source
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/display.md
+++ b/docs/latest/api/structures/display.md
@@ -1,7 +1,7 @@
 ---
 title: "Display Object"
 description: ""
-slug: display
+slug: /display
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/extension-info.md
+++ b/docs/latest/api/structures/extension-info.md
@@ -1,7 +1,7 @@
 ---
 title: "ExtensionInfo Object"
 description: ""
-slug: extension-info
+slug: /extension-info
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/extension.md
+++ b/docs/latest/api/structures/extension.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension Object"
 description: ""
-slug: extension
+slug: /extension
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/file-filter.md
+++ b/docs/latest/api/structures/file-filter.md
@@ -1,7 +1,7 @@
 ---
 title: "FileFilter Object"
 description: ""
-slug: file-filter
+slug: /file-filter
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/file-path-with-headers.md
+++ b/docs/latest/api/structures/file-path-with-headers.md
@@ -1,7 +1,7 @@
 ---
 title: "FilePathWithHeaders Object"
 description: ""
-slug: file-path-with-headers
+slug: /file-path-with-headers
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/filesystem-permission-request.md
+++ b/docs/latest/api/structures/filesystem-permission-request.md
@@ -1,7 +1,7 @@
 ---
 title: "FilesystemPermissionRequest Object extends `PermissionRequest`"
 description: ""
-slug: filesystem-permission-request
+slug: /filesystem-permission-request
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/gpu-feature-status.md
+++ b/docs/latest/api/structures/gpu-feature-status.md
@@ -1,7 +1,7 @@
 ---
 title: "GPUFeatureStatus Object"
 description: ""
-slug: gpu-feature-status
+slug: /gpu-feature-status
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/hid-device.md
+++ b/docs/latest/api/structures/hid-device.md
@@ -1,7 +1,7 @@
 ---
 title: "HIDDevice Object"
 description: ""
-slug: hid-device
+slug: /hid-device
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/input-event.md
+++ b/docs/latest/api/structures/input-event.md
@@ -1,7 +1,7 @@
 ---
 title: "InputEvent Object"
 description: ""
-slug: input-event
+slug: /input-event
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/ipc-main-event.md
+++ b/docs/latest/api/structures/ipc-main-event.md
@@ -1,7 +1,7 @@
 ---
 title: "IpcMainEvent Object extends `Event`"
 description: ""
-slug: ipc-main-event
+slug: /ipc-main-event
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/ipc-main-invoke-event.md
+++ b/docs/latest/api/structures/ipc-main-invoke-event.md
@@ -1,7 +1,7 @@
 ---
 title: "IpcMainInvokeEvent Object extends `Event`"
 description: ""
-slug: ipc-main-invoke-event
+slug: /ipc-main-invoke-event
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/ipc-main-service-worker-event.md
+++ b/docs/latest/api/structures/ipc-main-service-worker-event.md
@@ -1,7 +1,7 @@
 ---
 title: "IpcMainServiceWorkerEvent Object extends `Event`"
 description: ""
-slug: ipc-main-service-worker-event
+slug: /ipc-main-service-worker-event
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/ipc-main-service-worker-invoke-event.md
+++ b/docs/latest/api/structures/ipc-main-service-worker-invoke-event.md
@@ -1,7 +1,7 @@
 ---
 title: "IpcMainServiceWorkerInvokeEvent Object extends `Event`"
 description: ""
-slug: ipc-main-service-worker-invoke-event
+slug: /ipc-main-service-worker-invoke-event
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/ipc-renderer-event.md
+++ b/docs/latest/api/structures/ipc-renderer-event.md
@@ -1,7 +1,7 @@
 ---
 title: "IpcRendererEvent Object extends `Event`"
 description: ""
-slug: ipc-renderer-event
+slug: /ipc-renderer-event
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/jump-list-category.md
+++ b/docs/latest/api/structures/jump-list-category.md
@@ -1,7 +1,7 @@
 ---
 title: "JumpListCategory Object"
 description: ""
-slug: jump-list-category
+slug: /jump-list-category
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/jump-list-item.md
+++ b/docs/latest/api/structures/jump-list-item.md
@@ -1,7 +1,7 @@
 ---
 title: "JumpListItem Object"
 description: ""
-slug: jump-list-item
+slug: /jump-list-item
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/keyboard-event.md
+++ b/docs/latest/api/structures/keyboard-event.md
@@ -1,7 +1,7 @@
 ---
 title: "KeyboardEvent Object"
 description: ""
-slug: keyboard-event
+slug: /keyboard-event
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/keyboard-input-event.md
+++ b/docs/latest/api/structures/keyboard-input-event.md
@@ -1,7 +1,7 @@
 ---
 title: "KeyboardInputEvent Object extends `InputEvent`"
 description: ""
-slug: keyboard-input-event
+slug: /keyboard-input-event
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/media-access-permission-request.md
+++ b/docs/latest/api/structures/media-access-permission-request.md
@@ -1,7 +1,7 @@
 ---
 title: "MediaAccessPermissionRequest Object extends `PermissionRequest`"
 description: ""
-slug: media-access-permission-request
+slug: /media-access-permission-request
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/memory-info.md
+++ b/docs/latest/api/structures/memory-info.md
@@ -1,7 +1,7 @@
 ---
 title: "MemoryInfo Object"
 description: ""
-slug: memory-info
+slug: /memory-info
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/memory-usage-details.md
+++ b/docs/latest/api/structures/memory-usage-details.md
@@ -1,7 +1,7 @@
 ---
 title: "MemoryUsageDetails Object"
 description: ""
-slug: memory-usage-details
+slug: /memory-usage-details
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/mime-typed-buffer.md
+++ b/docs/latest/api/structures/mime-typed-buffer.md
@@ -1,7 +1,7 @@
 ---
 title: "MimeTypedBuffer Object"
 description: ""
-slug: mime-typed-buffer
+slug: /mime-typed-buffer
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/mouse-input-event.md
+++ b/docs/latest/api/structures/mouse-input-event.md
@@ -1,7 +1,7 @@
 ---
 title: "MouseInputEvent Object extends `InputEvent`"
 description: ""
-slug: mouse-input-event
+slug: /mouse-input-event
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/mouse-wheel-input-event.md
+++ b/docs/latest/api/structures/mouse-wheel-input-event.md
@@ -1,7 +1,7 @@
 ---
 title: "MouseWheelInputEvent Object extends `MouseInputEvent`"
 description: ""
-slug: mouse-wheel-input-event
+slug: /mouse-wheel-input-event
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/navigation-entry.md
+++ b/docs/latest/api/structures/navigation-entry.md
@@ -1,7 +1,7 @@
 ---
 title: "NavigationEntry Object"
 description: ""
-slug: navigation-entry
+slug: /navigation-entry
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/notification-action.md
+++ b/docs/latest/api/structures/notification-action.md
@@ -1,7 +1,7 @@
 ---
 title: "NotificationAction Object"
 description: ""
-slug: notification-action
+slug: /notification-action
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/notification-response.md
+++ b/docs/latest/api/structures/notification-response.md
@@ -1,7 +1,7 @@
 ---
 title: "NotificationResponse Object"
 description: ""
-slug: notification-response
+slug: /notification-response
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/offscreen-shared-texture.md
+++ b/docs/latest/api/structures/offscreen-shared-texture.md
@@ -1,7 +1,7 @@
 ---
 title: "OffscreenSharedTexture Object"
 description: ""
-slug: offscreen-shared-texture
+slug: /offscreen-shared-texture
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/open-external-permission-request.md
+++ b/docs/latest/api/structures/open-external-permission-request.md
@@ -1,7 +1,7 @@
 ---
 title: "OpenExternalPermissionRequest Object extends `PermissionRequest`"
 description: ""
-slug: open-external-permission-request
+slug: /open-external-permission-request
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/payment-discount.md
+++ b/docs/latest/api/structures/payment-discount.md
@@ -1,14 +1,14 @@
 ---
-title: "PaymentDiscount Object"
-description: ""
-slug: payment-discount
+title: 'PaymentDiscount Object'
+description: ''
+slug: /payment-discount
 hide_title: false
 ---
 
 # PaymentDiscount Object
 
-* `identifier` string - A string used to uniquely identify a discount offer for a product.
-* `keyIdentifier` string - A string that identifies the key used to generate the signature.
-* `nonce` string - A universally unique ID (UUID) value that you define.
-* `signature` string - A UTF-8 string representing the properties of a specific discount offer, cryptographically signed.
-* `timestamp` number - The date and time of the signature's creation in milliseconds, formatted in Unix epoch time.
+- `identifier` string - A string used to uniquely identify a discount offer for a product.
+- `keyIdentifier` string - A string that identifies the key used to generate the signature.
+- `nonce` string - A universally unique ID (UUID) value that you define.
+- `signature` string - A UTF-8 string representing the properties of a specific discount offer, cryptographically signed.
+- `timestamp` number - The date and time of the signature's creation in milliseconds, formatted in Unix epoch time.

--- a/docs/latest/api/structures/permission-request.md
+++ b/docs/latest/api/structures/permission-request.md
@@ -1,7 +1,7 @@
 ---
 title: "PermissionRequest Object"
 description: ""
-slug: permission-request
+slug: /permission-request
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/point.md
+++ b/docs/latest/api/structures/point.md
@@ -1,7 +1,7 @@
 ---
 title: "Point Object"
 description: ""
-slug: point
+slug: /point
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/post-body.md
+++ b/docs/latest/api/structures/post-body.md
@@ -1,7 +1,7 @@
 ---
 title: "PostBody Object"
 description: ""
-slug: post-body
+slug: /post-body
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/preload-script-registration.md
+++ b/docs/latest/api/structures/preload-script-registration.md
@@ -1,7 +1,7 @@
 ---
 title: "PreloadScriptRegistration Object"
 description: ""
-slug: preload-script-registration
+slug: /preload-script-registration
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/preload-script.md
+++ b/docs/latest/api/structures/preload-script.md
@@ -1,7 +1,7 @@
 ---
 title: "PreloadScript Object"
 description: ""
-slug: preload-script
+slug: /preload-script
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/printer-info.md
+++ b/docs/latest/api/structures/printer-info.md
@@ -1,7 +1,7 @@
 ---
 title: "PrinterInfo Object"
 description: ""
-slug: printer-info
+slug: /printer-info
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/process-memory-info.md
+++ b/docs/latest/api/structures/process-memory-info.md
@@ -1,7 +1,7 @@
 ---
 title: "ProcessMemoryInfo Object"
 description: ""
-slug: process-memory-info
+slug: /process-memory-info
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/process-metric.md
+++ b/docs/latest/api/structures/process-metric.md
@@ -1,7 +1,7 @@
 ---
 title: "ProcessMetric Object"
 description: ""
-slug: process-metric
+slug: /process-metric
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/product-discount.md
+++ b/docs/latest/api/structures/product-discount.md
@@ -1,7 +1,7 @@
 ---
 title: "ProductDiscount Object"
 description: ""
-slug: product-discount
+slug: /product-discount
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/product-subscription-period.md
+++ b/docs/latest/api/structures/product-subscription-period.md
@@ -1,7 +1,7 @@
 ---
 title: "ProductSubscriptionPeriod Object"
 description: ""
-slug: product-subscription-period
+slug: /product-subscription-period
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/product.md
+++ b/docs/latest/api/structures/product.md
@@ -1,7 +1,7 @@
 ---
 title: "Product Object"
 description: ""
-slug: product
+slug: /product
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/protocol-request.md
+++ b/docs/latest/api/structures/protocol-request.md
@@ -1,7 +1,7 @@
 ---
 title: "ProtocolRequest Object"
 description: ""
-slug: protocol-request
+slug: /protocol-request
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/protocol-response-upload-data.md
+++ b/docs/latest/api/structures/protocol-response-upload-data.md
@@ -1,7 +1,7 @@
 ---
 title: "ProtocolResponseUploadData Object"
 description: ""
-slug: protocol-response-upload-data
+slug: /protocol-response-upload-data
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/protocol-response.md
+++ b/docs/latest/api/structures/protocol-response.md
@@ -1,7 +1,7 @@
 ---
 title: "ProtocolResponse Object"
 description: ""
-slug: protocol-response
+slug: /protocol-response
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/proxy-config.md
+++ b/docs/latest/api/structures/proxy-config.md
@@ -1,7 +1,7 @@
 ---
 title: "ProxyConfig Object"
 description: ""
-slug: proxy-config
+slug: /proxy-config
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/rectangle.md
+++ b/docs/latest/api/structures/rectangle.md
@@ -1,7 +1,7 @@
 ---
 title: "Rectangle Object"
 description: ""
-slug: rectangle
+slug: /rectangle
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/referrer.md
+++ b/docs/latest/api/structures/referrer.md
@@ -1,7 +1,7 @@
 ---
 title: "Referrer Object"
 description: ""
-slug: referrer
+slug: /referrer
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/render-process-gone-details.md
+++ b/docs/latest/api/structures/render-process-gone-details.md
@@ -1,7 +1,7 @@
 ---
 title: "RenderProcessGoneDetails Object"
 description: ""
-slug: render-process-gone-details
+slug: /render-process-gone-details
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/resolved-endpoint.md
+++ b/docs/latest/api/structures/resolved-endpoint.md
@@ -1,7 +1,7 @@
 ---
 title: "ResolvedEndpoint Object"
 description: ""
-slug: resolved-endpoint
+slug: /resolved-endpoint
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/resolved-host.md
+++ b/docs/latest/api/structures/resolved-host.md
@@ -1,7 +1,7 @@
 ---
 title: "ResolvedHost Object"
 description: ""
-slug: resolved-host
+slug: /resolved-host
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/scrubber-item.md
+++ b/docs/latest/api/structures/scrubber-item.md
@@ -1,7 +1,7 @@
 ---
 title: "ScrubberItem Object"
 description: ""
-slug: scrubber-item
+slug: /scrubber-item
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/segmented-control-segment.md
+++ b/docs/latest/api/structures/segmented-control-segment.md
@@ -1,7 +1,7 @@
 ---
 title: "SegmentedControlSegment Object"
 description: ""
-slug: segmented-control-segment
+slug: /segmented-control-segment
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/serial-port.md
+++ b/docs/latest/api/structures/serial-port.md
@@ -1,7 +1,7 @@
 ---
 title: "SerialPort Object"
 description: ""
-slug: serial-port
+slug: /serial-port
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/service-worker-info.md
+++ b/docs/latest/api/structures/service-worker-info.md
@@ -1,7 +1,7 @@
 ---
 title: "ServiceWorkerInfo Object"
 description: ""
-slug: service-worker-info
+slug: /service-worker-info
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/shared-dictionary-info.md
+++ b/docs/latest/api/structures/shared-dictionary-info.md
@@ -1,7 +1,7 @@
 ---
 title: "SharedDictionaryInfo Object"
 description: ""
-slug: shared-dictionary-info
+slug: /shared-dictionary-info
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/shared-dictionary-usage-info.md
+++ b/docs/latest/api/structures/shared-dictionary-usage-info.md
@@ -1,7 +1,7 @@
 ---
 title: "SharedDictionaryUsageInfo Object"
 description: ""
-slug: shared-dictionary-usage-info
+slug: /shared-dictionary-usage-info
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/shared-worker-info.md
+++ b/docs/latest/api/structures/shared-worker-info.md
@@ -1,7 +1,7 @@
 ---
 title: "SharedWorkerInfo Object"
 description: ""
-slug: shared-worker-info
+slug: /shared-worker-info
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/sharing-item.md
+++ b/docs/latest/api/structures/sharing-item.md
@@ -1,7 +1,7 @@
 ---
 title: "SharingItem Object"
 description: ""
-slug: sharing-item
+slug: /sharing-item
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/shortcut-details.md
+++ b/docs/latest/api/structures/shortcut-details.md
@@ -1,7 +1,7 @@
 ---
 title: "ShortcutDetails Object"
 description: ""
-slug: shortcut-details
+slug: /shortcut-details
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/size.md
+++ b/docs/latest/api/structures/size.md
@@ -1,7 +1,7 @@
 ---
 title: "Size Object"
 description: ""
-slug: size
+slug: /size
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/task.md
+++ b/docs/latest/api/structures/task.md
@@ -1,7 +1,7 @@
 ---
 title: "Task Object"
 description: ""
-slug: task
+slug: /task
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/thumbar-button.md
+++ b/docs/latest/api/structures/thumbar-button.md
@@ -1,7 +1,7 @@
 ---
 title: "ThumbarButton Object"
 description: ""
-slug: thumbar-button
+slug: /thumbar-button
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/trace-categories-and-options.md
+++ b/docs/latest/api/structures/trace-categories-and-options.md
@@ -1,7 +1,7 @@
 ---
 title: "TraceCategoriesAndOptions Object"
 description: ""
-slug: trace-categories-and-options
+slug: /trace-categories-and-options
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/trace-config.md
+++ b/docs/latest/api/structures/trace-config.md
@@ -1,7 +1,7 @@
 ---
 title: "TraceConfig Object"
 description: ""
-slug: trace-config
+slug: /trace-config
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/transaction.md
+++ b/docs/latest/api/structures/transaction.md
@@ -1,7 +1,7 @@
 ---
 title: "Transaction Object"
 description: ""
-slug: transaction
+slug: /transaction
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/upload-data.md
+++ b/docs/latest/api/structures/upload-data.md
@@ -1,7 +1,7 @@
 ---
 title: "UploadData Object"
 description: ""
-slug: upload-data
+slug: /upload-data
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/upload-file.md
+++ b/docs/latest/api/structures/upload-file.md
@@ -1,7 +1,7 @@
 ---
 title: "UploadFile Object"
 description: ""
-slug: upload-file
+slug: /upload-file
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/upload-raw-data.md
+++ b/docs/latest/api/structures/upload-raw-data.md
@@ -1,7 +1,7 @@
 ---
 title: "UploadRawData Object"
 description: ""
-slug: upload-raw-data
+slug: /upload-raw-data
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/usb-device.md
+++ b/docs/latest/api/structures/usb-device.md
@@ -1,7 +1,7 @@
 ---
 title: "USBDevice Object"
 description: ""
-slug: usb-device
+slug: /usb-device
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/user-default-types.md
+++ b/docs/latest/api/structures/user-default-types.md
@@ -1,7 +1,7 @@
 ---
 title: "UserDefaultTypes Object"
 description: ""
-slug: user-default-types
+slug: /user-default-types
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/web-preferences.md
+++ b/docs/latest/api/structures/web-preferences.md
@@ -1,7 +1,7 @@
 ---
 title: "WebPreferences Object"
 description: ""
-slug: web-preferences
+slug: /web-preferences
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/web-request-filter.md
+++ b/docs/latest/api/structures/web-request-filter.md
@@ -1,7 +1,7 @@
 ---
 title: "WebRequestFilter Object"
 description: ""
-slug: web-request-filter
+slug: /web-request-filter
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/web-source.md
+++ b/docs/latest/api/structures/web-source.md
@@ -1,7 +1,7 @@
 ---
 title: "WebSource Object"
 description: ""
-slug: web-source
+slug: /web-source
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/window-open-handler-response.md
+++ b/docs/latest/api/structures/window-open-handler-response.md
@@ -1,7 +1,7 @@
 ---
 title: "WindowOpenHandlerResponse Object"
 description: ""
-slug: window-open-handler-response
+slug: /window-open-handler-response
 hide_title: false
 ---
 

--- a/docs/latest/api/structures/window-session-end-event.md
+++ b/docs/latest/api/structures/window-session-end-event.md
@@ -1,7 +1,7 @@
 ---
 title: "WindowSessionEndEvent Object extends `Event`"
 description: ""
-slug: window-session-end-event
+slug: /window-session-end-event
 hide_title: false
 ---
 


### PR DESCRIPTION
#### Description of Change

This PR updates all `.md` files in `docs/latest/api/structures/`, correcting the `slug` field format.  
Previously, slugs were written as:
```slug: path```
Now, they are properly prefixed with /:
```slug: /path```

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
