### PR TITLE
fix wdio/playwright code

### DIFF
--- a/docs/latest/tutorial/automated-testing.md
+++ b/docs/latest/tutorial/automated-testing.md
@@ -83,44 +83,21 @@ Furthermore, WebdriverIO allows you to access Electron APIs to get static inform
 ```js @ts-nocheck
 import { browser, $, expect } from '@wdio/globals'
 
-describe('when the make smaller button is clicked', () => {
-  it('should decrease the window height and width by 10 pixels', async () => {
-    const boundsBefore = await browser.electron.browserWindow('getBounds')
-    expect(boundsBefore.width).toEqual(210)
-    expect(boundsBefore.height).toEqual(310)
-
-    await $('.make-smaller').click()
-    const boundsAfter = await browser.electron.browserWindow('getBounds')
-    expect(boundsAfter.width).toEqual(200)
-    expect(boundsAfter.height).toEqual(300)
-  })
-})
-```
-
-or to retrieve other Electron process information:
-
-```js @ts-nocheck
-import fs from 'node:fs'
-import path from 'node:path'
-import { browser, expect } from '@wdio/globals'
-
-const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), { encoding: 'utf-8' }))
-const { name, version } = packageJson
-
-describe('electron APIs', () => {
-  it('should retrieve app metadata through the electron API', async () => {
-    const appName = await browser.electron.app('getName')
-    expect(appName).toEqual(name)
-    const appVersion = await browser.electron.app('getVersion')
-    expect(appVersion).toEqual(version)
-  })
-
-  it('should pass args through to the launched application', async () => {
-    // custom args are set in the wdio.conf.js file as they need to be set before WDIO starts
-    const argv = await browser.electron.mainProcess('argv')
-    expect(argv).toContain('--foo')
-    expect(argv).toContain('--bar=baz')
-  })
+describe('trriger message modal', async () => {
+  it('message modal can be triggered from a test', async () => {
+    await browser.electron.execute(
+      (electron, param1, param2, param3) => {
+        const appWindow = electron.BrowserWindow.getFocusedWindow();
+        electron.dialog.showMessageBox(appWindow, {
+          message: 'Hello World!',
+          detail: `${param1} + ${param2} + ${param3} = ${param1 + param2 + param3}`,
+        });
+      },
+      1,
+      2,
+      3,
+    );
+  });
 })
 ```
 
@@ -212,7 +189,7 @@ npm install --save-dev @playwright/test
 
 :::caution Dependencies
 
-This tutorial was written with `@playwright/test@1.41.1`. Check out
+This tutorial was written with `@playwright/test@1.52.0`. Check out
 [Playwright's releases][playwright-releases] page to learn about
 changes that might affect the code below.
 
@@ -225,10 +202,10 @@ To point this API to your Electron app, you can pass the path to your main proce
 entry point (here, it is `main.js`).
 
 ```js {5} @ts-nocheck
-const { test, _electron: electron } = require('@playwright/test')
+import { test, _electron as electron } from "@playwright/test";
 
 test('launch app', async () => {
-  const electronApp = await electron.launch({ args: ['main.js'] })
+  const electronApp = await electron.launch({ args: ['.'] })
   // close app
   await electronApp.close()
 })
@@ -238,10 +215,10 @@ After that, you will access to an instance of Playwright's `ElectronApp` class. 
 is a powerful class that has access to main process modules for example:
 
 ```js {5-10} @ts-nocheck
-const { test, _electron: electron } = require('@playwright/test')
+import { test, _electron as electron } from "@playwright/test";
 
 test('get isPackaged', async () => {
-  const electronApp = await electron.launch({ args: ['main.js'] })
+  const electronApp = await electron.launch({ args: ['.'] })
   const isPackaged = await electronApp.evaluate(async ({ app }) => {
     // This runs in Electron's main process, parameter here is always
     // the result of the require('electron') in the main app script.
@@ -257,10 +234,11 @@ It can also create individual [Page][playwright-page] objects from Electron Brow
 For example, to grab the first BrowserWindow and save a screenshot:
 
 ```js {6-7} @ts-nocheck
-const { test, _electron: electron } = require('@playwright/test')
+import { test, _electron as electron } from "@playwright/test";
+
 
 test('save screenshot', async () => {
-  const electronApp = await electron.launch({ args: ['main.js'] })
+  const electronApp = await electron.launch({ args: ['.'] })
   const window = await electronApp.firstWindow()
   await window.screenshot({ path: 'intro.png' })
   // close app


### PR DESCRIPTION
#### Description of Change

While investigating the E2E test, I found some problems with the documentation, so I created this PR. The following corrections have been made.

(1) wdio sample code may be old and not functional

Both of the original codes (accessing Electron APIs) seemed to not work due to API changes on the WDIO side. I have replaced it with the sample from their documentation (https://webdriver.io/docs/desktop-testing/electron/api/).

The original code can be made to work by doing the following, but it is not a good sample, so I am replacing it.

```
import { browser, expect, $ } from "@wdio/globals";

describe("when the make smaller button is clicked", () => {
  it("should decrease the window height and width by 10 pixels", async () => {
    const boundsBefore = await browser.electron.execute((electron) => {
      const win = electron.BrowserWindow.getFocusedWindow();
      return win.getBounds();
    });

    expect(boundsBefore.width).toEqual(210);
    expect(boundsBefore.height).toEqual(310);

    await $(".make-smaller").click();

    const boundsAfter = await browser.electron.execute((electron) => {
      const win = electron.BrowserWindow.getFocusedWindow();
      return win.getBounds();
    });
    expect(boundsAfter.width).toEqual(200);
    expect(boundsAfter.height).toEqual(300);
  });
});
```

(2) playwright code optimization

- Comfirmed working with latest playwright version (1.52.0).
- Changed require to import.
- The entry points are changed to “.” as in the last sample code.

#### Checklist

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
