### PR TITLE
style(fiddle-embed): add bottom margin

### DIFF
--- a/src/components/FiddleEmbed.module.scss
+++ b/src/components/FiddleEmbed.module.scss
@@ -11,6 +11,7 @@
   border: 3px solid var(--ifm-color-emphasis-200);
   border-radius: var(--ifm-global-radius);
   box-shadow: var(--ifm-global-shadow-md);
+  margin-bottom: var(--ifm-leading);
 }
 
 .editorWindowHeader {


### PR DESCRIPTION
Small change that makes it so that adding other elements after a Fiddle embed has proper spacing.

