### PR TITLE
chore: link to subreddit from community page

### DIFF
--- a/src/pages/community/index.tsx
+++ b/src/pages/community/index.tsx
@@ -23,7 +23,8 @@ function Community() {
           </li>
           <li>
             🙋 <strong>Get help and feedback</strong> by joining the{' '}
-            <a href="https://discord.gg/electronjs">Discord server</a>, or
+            <a href="https://discord.gg/electronjs">Discord server</a>,{' '}
+            <a href="https://www.reddit.com/r/electronjs">subreddit</a>, or
             visiting{' '}
             <a href="https://stackoverflow.com/questions/tagged/electron">
               Stack Overflow


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

I often send people to the community page when they ask questions in the issue tracker.

I noticed codebytere often also mentions the subreddit, so I thought we should mention it on the community page.

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
