### PR TITLE
style: revert to default mapping for admonitions

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -262,10 +262,7 @@ const config: Config = {
             [
               remarkGithubAdmonitionsToDirectives,
               {
-                mapping: {
-                  ...DEFAULT_MAPPING,
-                  [GithubAlertType.NOTE]: DirectiveName.INFO,
-                },
+                mapping: DEFAULT_MAPPING,
               },
             ],
           ],


### PR DESCRIPTION
Reverts `NOTE` to `:::note` and keeps `IMPORTANT` as `:::info`. It's nice to distinguish between the two levels since we're probably going to be writing in GitHub-flavoured admonition syntax going forward.