### PR TITLE
chore: update MAS link in home page

### DIFF
--- a/src/pages/home/_index.tsx
+++ b/src/pages/home/_index.tsx
@@ -138,9 +138,7 @@ export default function Home() {
             >
               Distribute your application to more users. Electron has
               first-class support for the{' '}
-              <Link to="https://www.apple.com/ca/osx/apps/app-store/index.html">
-                Mac App Store
-              </Link>{' '}
+              <Link to="https://www.apple.com/app-store/">Mac App Store</Link>{' '}
               (macOS), the{' '}
               <Link to="https://apps.microsoft.com/">Microsoft Store</Link>{' '}
               (Windows), or the{' '}


### PR DESCRIPTION
https://www.apple.com/ca/osx/apps/app-store/index.html only redirects nowadays, unfortunately.