### PR TITLE
style: homepage tweaks

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -123,12 +123,6 @@ const config: Config = {
           ],
         },
         {
-          label: 'Why Electron',
-          type: 'doc',
-          docId: 'latest/why-electron',
-          position: 'left',
-        },
-        {
           href: 'https://releases.electronjs.org',
           label: 'Releases',
           position: 'right',

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -207,7 +207,7 @@ html {
 
 .button {
   &--outline {
-    border: 1px solid;
+    outline: 1px solid;
     color: var(--ifm-color-primary);
     &:hover {
       color: var(--ifm-color-primary-dark);
@@ -228,6 +228,11 @@ html {
       background: var(--electron-color-light);
       border-color: var(--electron-color-light);
       color: black;
+    }
+
+    &.button--outline {
+      background: transparent;
+      color: var(--electron-color-light);
     }
   }
 }

--- a/src/pages/home/_index.tsx
+++ b/src/pages/home/_index.tsx
@@ -32,10 +32,22 @@ export default function Home() {
             <div className={clsx('col col--12', styles.heroHeadline)}>
               <h1>{siteConfig.tagline}</h1>
               <Link
-                className="button button--electron button--dark button--lg"
+                className="button button--electron button--dark margin-right--sm"
                 to="/docs/latest/"
               >
-                Docs
+                Get Started →
+              </Link>
+              <Link
+                className="button button--electron button--outline button--dark margin-right--sm"
+                to="/docs/latest/why-electron"
+              >
+                Why Electron?
+              </Link>
+              <Link
+                className="button button--electron button--outline button--dark"
+                to="https://github.com/electron/electron"
+              >
+                View on GitHub
               </Link>
             </div>
           </div>
@@ -240,10 +252,6 @@ export default function Home() {
             <div className={clsx(styles.section)}>
               <div className={clsx(styles.explore, 'row')}>
                 <div className="col margin-bottom--lg">
-                  <div className="badge badge--info">
-                    <span className={styles.exploreSubtext}>New!</span>
-                  </div>
-
                   <h2>Electron Forge</h2>
                   <p>
                     Electron Forge is a batteries-included toolkit for building


### PR DESCRIPTION
* Renamed "Docs" to "Get Started"
* Moved "Why Electron?" from the navbar to the homepage hero
* Added link to GitHub in hero
* Removed "NEW" tag from Electron Forge element