### PR TITLE
build: delete stale files on upload (dry-run)

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -2,7 +2,7 @@ name: Push and publish main
 
 on:
   schedule:
-    # twice a day at midnight and noon
+    # twice a day at midnight and noon UTC
     - cron: '0 0,12 * * *'
   push:
     branches:
@@ -75,6 +75,7 @@ jobs:
           timeout_seconds: 300
           max_attempts: 3
           retry_on: error
-          command: ./scripts/bin/azcopy copy "./build/*" "https://electronwebsite.blob.core.windows.net/%24web/?$SAS" --recursive
+          # Ensure that we upload the default locale and remove deleted files but don't touch translations
+          command: cd ./build && ./scripts/bin/azcopy sync "./" "https://electronwebsite.blob.core.windows.net/%24web/?$SAS" --delete-destination=true --exclude-regex="pt/*;ja/*;ru/*;fr/*;zh/*;es/*;de/*;" --dry-run
         env:
           SAS: ${{ secrets.SAS }}

--- a/.github/workflows/update-i18n-deploy.yml
+++ b/.github/workflows/update-i18n-deploy.yml
@@ -2,7 +2,8 @@ name: 'Update i18n deploy'
 
 on:
   schedule:
-    - cron: '0 0,12 * * *'
+    # twice a day at 8:00 and 16:00 UTC
+    - cron: '0 8,16 * * *'
   workflow_dispatch:
 
 permissions:
@@ -45,6 +46,7 @@ jobs:
         run: yarn i18n:build
 
       - name: Deploy
-        run: ./scripts/bin/azcopy copy "./build/*" "https://electronwebsite.blob.core.windows.net/%24web?$SAS" --recursive
+        # The i18n build produces the default locale anyways so we can just sync the whole build directory
+        run: cd build && ./scripts/bin/azcopy sync "./" "https://electronwebsite.blob.core.windows.net/%24web?$SAS" --delete-destination=true --dry-run
         env:
           SAS: ${{ secrets.SAS }}

--- a/src/transformers/api-options-class.ts
+++ b/src/transformers/api-options-class.ts
@@ -33,7 +33,11 @@ async function transformer(tree: Parent) {
 
 function visitor(node: ListItem) {
   if (
+    Array.isArray(node.children) &&
+    node.children.length > 0 &&
     isParagraph(node.children[0]) &&
+    Array.isArray(node.children[0].children) &&
+    node.children[0].children.length > 0 &&
     isOptions(node.children[0].children[0])
   ) {
     const hastProperties = {


### PR DESCRIPTION
Uses `azcopy sync --delete-destination` instead of `azcopy copy` so that stale files can be deleted from the website.

Uses the `--dry-run` flag so we don't mess anything up. Will trigger a workflow dispatch and then remove the flag in a follow-up PR if the dry run logs look good.

Unrelated MDX fix to make the i18n build more tolerant to faulty translation strings.