### PR TITLE
build: use MD5 compare for sync (no dry run)

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -76,6 +76,6 @@ jobs:
           max_attempts: 3
           retry_on: error
           # Ensure that we upload the default locale and remove deleted files but don't touch translations
-          command: cd ./build && ../scripts/bin/azcopy sync "./" "https://electronwebsite.blob.core.windows.net/%24web/?$SAS" --delete-destination=true --exclude-regex="pt/*;ja/*;ru/*;fr/*;zh/*;es/*;de/*;" --dry-run
+          command: cd ./build && ../scripts/bin/azcopy sync "./" "https://electronwebsite.blob.core.windows.net/%24web/?$SAS" --delete-destination=true --exclude-regex="pt/*;ja/*;ru/*;fr/*;zh/*;es/*;de/*;" --compare-hash=MD5
         env:
           SAS: ${{ secrets.SAS }}

--- a/.github/workflows/update-i18n-deploy.yml
+++ b/.github/workflows/update-i18n-deploy.yml
@@ -47,6 +47,6 @@ jobs:
 
       - name: Deploy
         # The i18n build produces the default locale anyways so we can just sync the whole build directory
-        run: cd build && ./scripts/bin/azcopy sync "./" "https://electronwebsite.blob.core.windows.net/%24web?$SAS" --delete-destination=true --dry-run
+        run: cd build && ./scripts/bin/azcopy sync "./" "https://electronwebsite.blob.core.windows.net/%24web?$SAS" --delete-destination=true --compare-hash=MD5
         env:
           SAS: ${{ secrets.SAS }}


### PR DESCRIPTION
Uses the `--compare-hash=MD5` flag to sync files that have changed based on their contents instead of last timestamp.

Also removes `--dry-run` so that we can test this live.