### PR TITLE
build: add log upload, increase upload timeout

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Publish everything to Storage
         uses: nick-invision/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # tag: v3.0.2
         with:
-          timeout_seconds: 300
+          timeout_seconds: 3000
           max_attempts: 3
           retry_on: error
           # Ensure that we upload the default locale and remove deleted files but don't touch translations

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -79,3 +79,10 @@ jobs:
           command: cd ./build && ../scripts/bin/azcopy sync "./" "https://electronwebsite.blob.core.windows.net/%24web/?$SAS" --delete-destination=true --exclude-regex="pt/*;ja/*;ru/*;fr/*;zh/*;es/*;de/*;" --compare-hash=MD5
         env:
           SAS: ${{ secrets.SAS }}
+      - name: Upload logging
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
+        with:
+          name: debug-log
+          path: .azcopy/*.log
+          include-hidden-files: true
+          retention-days: 3


### PR DESCRIPTION
#### Description of Change

Adds the ability to upload log files for the azcopy command and also ups the timeout limit on storage upload

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
