### PR TITLE
build: disable rspack persistent cache

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -60,9 +60,9 @@ jobs:
             ${{ github.workspace }}/.docusaurus
             ${{ github.workspace }}/**/.cache
           key: |
-            ${{ runner.os }}-docusaurus-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+            ${{ runner.os }}-docusaurus-v2-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
           restore-keys: |
-            ${{ runner.os }}-docusaurus-${{ hashFiles('**/yarn.lock') }}
+            ${{ runner.os }}-docusaurus-v2-${{ hashFiles('**/yarn.lock') }}
       - name: Add Docusaurus problem matcher
         run: echo "::add-matcher::.github/problem-matchers/docusaurus.json"
       - name: Build default locale site

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -296,7 +296,16 @@ const config: Config = {
     ],
   ],
   future: {
-    experimental_faster: true,
+    experimental_faster: {
+      rspackBundler: true,
+      rspackPersistentCache: false,
+      swcHtmlMinimizer: true,
+      ssgWorkerThreads: true,
+      swcJsLoader: true,
+      swcJsMinimizer: true,
+      lightningCssMinimizer: true,
+      mdxCrossCompilerCache: true,
+    },
     v4: {
       removeLegacyPostBuildHeadAttribute: true,
       // FIXME: enabling this change breaks compilation


### PR DESCRIPTION
This is new with Docusaurus 3.8 and potentially causes issues with the build: https://docusaurus.io/blog/releases/3.8#persistent-cache