### PR TITLE
ci: change automated docs update to use PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
 * @electron/wg-ecosystem
 /blog/ @electron/wg-outreach
+
+# There is no code owner for the docs directory
+# so that bots can approve automated PRs to it
+/docs/

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -18,6 +18,10 @@ jobs:
   update-docs:
     runs-on: ubuntu-latest
     environment: docs-updater
+    env:
+      SHA: ${{ github.event.client_payload.sha || github.event.inputs.sha }}
+    permissions:
+      pull-requests: write
     steps:
       - name: Generate GitHub App token
         uses: electron/github-app-auth-action@384fd19694fe7b6dcc9a684746c6976ad78228ae # v1.1.1
@@ -35,14 +39,35 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Prebuild
         run: |
-          yarn pre-build ${{ github.event.client_payload.sha || github.event.inputs.sha }}
+          yarn pre-build ${SHA}
           git add .
           if [ "$(git status --porcelain | grep -v 'docs/latest/.sha')" = "" ]; then
             echo "Unexpectedly found no new content for docs - this is probably a bug"
             exit 1
           fi
-      - name: Push changes
+      - name: Push changes to branch
         uses: dsanders11/github-app-commit-action@43de6da2f4d927e997c0784c7a0b61bd19ad6aac # v1.5.0
         with:
           message: 'chore: update ref to docs (🤖)'
+          ref: 'docs/update-to-${{ env.SHA }}'
           token: ${{ steps.generate-token.outputs.token }}
+      - name: Create pull request
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh pr create \
+            --title "chore: update ref to docs (🤖)" \
+            --body "Automated PR to update the docs to the latest commit (${{
+              github.event.client_payload.sha || github.event.inputs.sha
+            }})" \
+            --head "docs/update-to-${SHA}" \
+            --base main
+      - name: Approve and merge pull request
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(gh pr list --head "docs/update-to-${SHA}" --json number --jq '.[0].number')
+          gh pr review ${PR_NUMBER} --approve
+          gh pr merge ${PR_NUMBER} --auto --squash


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

We have some required status checks now which require a PR, and that's breaking our existing automation solution of pushing straight to `main`. Run everything through a PR which the existing GitHub app will create, and then use the generic GitHub Actions app to approve and merge the PR.

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [ ] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
