### PR TITLE
docs: fix incorrect v38 release notes bullet point

### DIFF
--- a/blog/electron-38-0.md
+++ b/blog/electron-38-0.md
@@ -33,7 +33,7 @@ Electron 38 upgrades Chromium from `138.0.7204.35` to `140.0.7339.41`, Node from
 
 - Added support for customizing system accent color and highlighting of active window border. [#47285](https://github.com/electron/electron/pull/47285) (Also in [37](https://github.com/electron/electron/pull/47537))
 - Added `fileBacked` and `purgeable` fields to `process.getSystemMemoryInfo()` for macOS. [#48146](https://github.com/electron/electron/pull/48146) (Also in [37](https://github.com/electron/electron/pull/48143))
-- Added `tray.{get|set}AutosaveName` to enable macOS tray icons to maintain position across launches. [#48077](https://github.com/electron/electron/pull/48077) (Also in [37](https://github.com/electron/electron/pull/48076))
+- Added support for `guid` `Tray` constructor option on macOS to allow tray icons to maintain position across launches. [#48077](https://github.com/electron/electron/pull/48077) (Also in [37](https://github.com/electron/electron/pull/48076))
 - Added `webFrameMain.fromFrameToken(processId, frameToken)` to get a `WebFrameMain` instance from its frame token. [#47942](https://github.com/electron/electron/pull/47942)
 - Added support for `app.getRecentDocuments()` on Windows and macOS. [#47924](https://github.com/electron/electron/pull/47924) (Also in [37](https://github.com/electron/electron/pull/47923))
 - Internally switched to using `DIR_ASSETS` instead of `DIR_MODULE`/`DIR_EXE` to locate assets and resources, and added "assets" as a key that can be queried via `app.getPath`. [#47950](https://github.com/electron/electron/pull/47950) (Also in [37](https://github.com/electron/electron/pull/47951))


### PR DESCRIPTION
#### Description of Change

<!-- Thank you for your Pull Request. Please describe your change here. -->

The API was changed before the PR was merged. The release notes for the PR didn't get updated before merging.

I've updated the release notes after the PR was merged. This now also updates the blog post.

See the PR this entry is referring to: https://github.com/electron/electron/pull/47838

#### Checklist

<!-- Please confirm the following by changing [ ] to [x]. -->

- [x] This PR was not created with AI. (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.)
